### PR TITLE
github actions macOS打包

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,183 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+  workflow_dispatch:
+    inputs:
+      macos-aarch64:
+        description: 'Build macOS aarch64 app'
+        required: false
+        type: boolean
+        default: false
+      macos-x86_64:
+        description: 'Build macOS x86_64 app'
+        required: false
+        type: boolean
+        default: true
+      windows:
+        description: 'Build windows app'
+        required: false
+        type: boolean
+        default: true
+
+env:
+  PYTHON_VERSION: '3.10'
+  MACOS_BUNDLE_ID: com.mdcuniverse.mdcx
+
+jobs:
+  init-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      # https://github.com/actions/runner/issues/1985#issuecomment-1573518052
+      - name: Set matrix
+        id: set-matrix
+        run: |
+          items=()
+
+          # https://docs.github.com/zh/actions/hosting-your-own-runners/managing-self-hosted-runners/adding-self-hosted-runners
+          if [[ ${{ github.event.inputs.macos-aarch64 }} == "true" ]]; then
+            items+=('{"build":"macos", "os": ["self-hosted", "macOS", "ARM64"], "arch": "aarch64"}')
+          fi
+
+          if [[ ${{ github.event.inputs.macos-x86_64 }} == "true" ]]; then
+            items+=('{"build": "macos", "os": "macos-latest", "arch": "x86_64"}')
+          fi
+
+          if [[ ${{ github.event.inputs.windows }} == "true" ]]; then
+            items+=('{"build": "windows", "os": "windows-latest", "arch": "x86_64"}')
+          fi 
+          
+          # 合并items到json数组
+          matrix="matrix=["
+          for ((i=0; i<${#items[@]}; i++)); do
+            matrix+=" ${items[i]}"
+            if ((i != ${#items[@]}-1)); then
+              matrix+=","
+            fi
+          done
+          matrix+="]"
+
+          # 输出matrix到GITHUB_OUTPUT
+          echo $matrix >> $GITHUB_OUTPUT
+
+  build-app:
+    needs: init-matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{fromJson(needs.init-matrix.outputs.matrix)}}
+    steps:
+      - name: Set env
+        run: |
+          # 如果是release触发的workflow，则获取release的tag，作为版本号
+          if [[ ${{ github.event_name }} == "release" ]]; then
+            echo "RELEASE_TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+          fi
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      
+      - name: Install libraries
+        if: ${{ matrix.build == 'macos' }}
+        run: |
+          # FIX: No package 'gobject-introspection-1.0' found
+          # https://tutorials.technology/solved_errors/osx-gobject-introspection-1_0-found.html
+          brew install gobject-introspection
+
+      - name: Install dependencies - macOS
+        if: ${{ matrix.build == 'macos' }}
+        run: |
+          python -m pip install --upgrade pip
+          
+          python -m pip install -r requirements-mac.txt
+
+          pip install pyinstaller
+
+      - name: Install dependencies - Windows
+        if: ${{ matrix.build == 'windows' }}
+        run: |
+          python -m pip install --upgrade pip
+          
+          python -m pip install -r requirements.txt
+
+          pip install pyinstaller
+
+      - name: Create spec file - macOS
+        if: ${{ matrix.build == 'macos' }}
+        run: |
+          pyi-makespec \
+            --name MDCx \
+            --osx-bundle-identifier ${{ env.MACOS_BUNDLE_ID }} \
+            -F -w main.py \
+            -p "./src" \
+            --add-data "resources:resources" \
+            --add-data "libs:." \
+            --icon resources/Img/MDCx.icns \
+            --hidden-import socks \
+            --hidden-import urllib3 \
+            --hidden-import _cffi_backend \
+            --collect-all curl_cffi
+      
+      - name: Create spec file - Windows
+        if: ${{ matrix.build == 'windows' }}
+        run: |
+          # 默认的shell是PowerShell
+
+          pyi-makespec `
+            --name MDCx `
+            -F -w main.py `
+            -p "./src" `
+            --add-data "resources;resources" `
+            --add-data "libs;." `
+            --icon resources/Img/MDCx.ico `
+            --hidden-import socks `
+            --hidden-import urllib3 `
+            --hidden-import _cffi_backend `
+            --collect-all curl_cffi
+
+      - name: Build macOS app - macOS
+        if: ${{ matrix.build == 'macos' }}
+        run: |
+          pyinstaller MDCx.spec
+
+          cd dist
+          rm MDCx
+          
+          # `upload-artifact`会使文件丢失可执行权限。解决思路，先把`dist`打包成zip，再上传
+          zip -r ../MDCx-${{ matrix.build }}-${{ matrix.arch }}.app.zip .
+
+      - name: Build Windows app - Windows
+        if: ${{ matrix.build == 'windows' }}
+        run: |
+          pyinstaller MDCx.spec
+
+          # 创建文件夹
+          New-Item -ItemType Directory -Path "MDCx"
+
+          # 移动文件
+          Move-Item -Path dist\MDCx.exe -Destination MDCx\MDCx-${{ matrix.build }}-${{ matrix.arch }}.exe
+
+      - name: Upload artifact - macOS
+        uses: actions/upload-artifact@v3
+        if: ${{ matrix.build == 'macos' }}
+        with:
+          name: MDCx-${{ matrix.build }}-${{ matrix.arch }}
+          path: |
+            ./**.app.zip
+
+      - name: Upload artifact - Windows
+        uses: actions/upload-artifact@v3
+        if: ${{ matrix.build == 'windows' }}
+        with:
+          name: MDCx-${{ matrix.build }}-${{ matrix.arch }}
+          path: |
+            .\MDCx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ on:
 
 env:
   PYTHON_VERSION: '3.10'
-  MACOS_BUNDLE_ID: com.mdcuniverse.mdcx
+  MACOS_BUNDLE_ID: com.mdcxuniverse.mdcx
 
 jobs:
   init-matrix:
@@ -72,12 +72,12 @@ jobs:
       matrix:
         include: ${{fromJson(needs.init-matrix.outputs.matrix)}}
     steps:
-      - name: Set env
-        run: |
-          # 如果是release触发的workflow，则获取release的tag，作为版本号
-          if [[ ${{ github.event_name }} == "release" ]]; then
-            echo "RELEASE_TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
-          fi
+      # - name: Set env
+      #   run: |
+      #     # 如果是release触发的workflow，则获取release的tag，作为版本号
+      #     if [[ "${{ github.event_name }}" == "release" ]]; then
+      #       echo "RELEASE_TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+      #     fi
       - name: Checkout code
         uses: actions/checkout@v2
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,11 @@ __pycache__/
 # C extensions
 *.so
 
+.DS_Store
+
+Thumbs.db
+Desktop.ini
+
 # Distribution / packaging
 .Python
 build/

--- a/build-macos.sh
+++ b/build-macos.sh
@@ -1,0 +1,25 @@
+#/bin/bash
+
+# Sample build script for pyinstaller
+
+appName="MDCx"
+
+pyi-makespec \
+  --name MDCx \
+  --osx-bundle-identifier com.mdcuniverse.mdcx \
+  -F -w main.py \
+  -p "./src" \
+  --add-data "resources:resources" \
+  --add-data "libs:." \
+  --icon resources/Img/MDCx.icns \
+  --hidden-import socks \
+  --hidden-import urllib3 \
+  --hidden-import _cffi_backend \
+  --collect-all curl_cffi
+
+rm -rf ./dist
+
+pyinstaller MDCx.spec
+
+rm -rf ./build
+rm *.spec

--- a/requirements-mac.txt
+++ b/requirements-mac.txt
@@ -4,7 +4,8 @@ cloudscraper==1.2.71
 requests==2.24.0
 beautifulsoup4==4.9.3
 Pillow==9.4.0
-PyQt5==5.15.6
+# 5.15.6 stuck on m1 Ventura 13.5, 5.15.10 is fine
+PyQt5==5.15.10
 PySocks==1.7.1
 urllib3==1.25.11
 zhconv

--- a/src/controllers/main_window/main_window.py
+++ b/src/controllers/main_window/main_window.py
@@ -1673,7 +1673,7 @@ class MyMAinWindow(QMainWindow):
         media_folder_path = convert_path(self._get_select_folder_path())
         if media_folder_path and media_folder_path != config.folder:
             config_path = os.path.join(media_folder_path, 'config.ini')
-            with open('MDCx.config', 'w', encoding='UTF-8') as f:
+            with open(config.get_mark_file_path(), 'w', encoding='UTF-8') as f:
                 f.write(config_path)
             if os.path.isfile(config_path):
                 temp_dark = self.dark_mode
@@ -1954,7 +1954,7 @@ class MyMAinWindow(QMainWindow):
             new_config_path = os.path.join(config.folder, new_config_file)
             signal.show_log_text(
                 '\n================================================================================\n切换配置：%s' % new_config_path)
-            with open('MDCx.config', 'w', encoding='UTF-8') as f:
+            with open(config.get_mark_file_path(), 'w', encoding='UTF-8') as f:
                 f.write(new_config_path)
             temp_dark = self.dark_mode
             temp_window_radius = self.window_radius

--- a/src/models/base/path.py
+++ b/src/models/base/path.py
@@ -1,11 +1,13 @@
 # 主程序路径
 import os
+import platform
 import re
 import sys
 import traceback
 from os.path import abspath, dirname, realpath
 
 from models.signals import signal
+from models.config.config import config
 
 
 def get_main_path():
@@ -20,7 +22,10 @@ def get_main_path():
         # 或sys.argv[0],取的是被初始执行的脚本的所在目录，打包后路径会变成\base_libarary.zip
         # base_path = abspath(".") 取的是起始执行目录，和os.getcwd()结果一样，不太准
     if getattr(sys, 'frozen', False):  # 是否Bundle Resource，是否打包成exe运行
-        main_path = abspath("")  # 打包后，路径是准的
+        if platform.system() == 'Darwin':
+            main_path = config.get_mac_default_config_folder()
+        else:
+            main_path = abspath("")  # 打包后，路径是准的
     return main_path
 
 

--- a/src/models/config/config.py
+++ b/src/models/config/config.py
@@ -13,6 +13,9 @@ from models.config.config_manual import ManualConfig
 
 @singleton
 class MDCxConfig(GeneratedConfig, ManualConfig):
+
+    mark_file_name = 'MDCx.config'
+
     def __init__(self):
         self.file = None
         self.folder = None
@@ -33,6 +36,34 @@ class MDCxConfig(GeneratedConfig, ManualConfig):
     @path.getter
     def path(self):
         return self._path
+    
+    def get_mac_default_config_folder(self):
+        """
+        获取macOS下默认的配置文件夹路径
+
+        ~/.mdcx
+
+        :return: 配置文件夹路径
+        """
+
+        home = os.path.expanduser('~')
+        folder_name = '.mdcx'
+        config_folder = os.path.join(home, folder_name)
+        if not os.path.exists(config_folder):
+            os.makedirs(config_folder, exist_ok=True, mode=0o755)
+        return config_folder
+
+    def get_mark_file_path(self):
+        """
+        获取`记录了配置文件路径`的文件的路径。
+        对于macOS，该文件位于`~/.mdcx/MDCx.config`。
+        其他平台，该文件跟应用程序在同一目录下。
+        """
+
+        if platform.system() == 'Darwin':
+            return os.path.join(self.get_mac_default_config_folder(), self.mark_file_name)
+        else:
+            return self.mark_file_name
 
     def read_config(self):
         self._get_config_path()
@@ -51,7 +82,7 @@ class MDCxConfig(GeneratedConfig, ManualConfig):
         self._update_config()
 
     def save_config(self):
-        with open('MDCx.config', 'w', encoding='UTF-8') as f:
+        with open(self.get_mark_file_path(), 'w', encoding='UTF-8') as f:
             f.write(self.path)
         with open(self.path, "wt", encoding='UTF-8') as code:
             # 使用反射保存自定义网址设置
@@ -380,10 +411,13 @@ statement = {self.statement}
         self.suffix_sort = new_str
 
     def _get_config_path(self):
-        mdcx_config = 'MDCx.config'  # 此文件用于记录当前配置文件的绝对路径, 从而实现多配置切换
+        mdcx_config = self.get_mark_file_path()  # 此文件用于记录当前配置文件的绝对路径, 从而实现多配置切换
         # 此文件必须存在, 且与 main.py 或打包的可执行文件在同一目录下.
         if not os.path.exists(mdcx_config):  # 不存在时, 创建
-            self.path = os.path.realpath('config.ini')  # 默认配置文件: 同目录下的 config.ini
+            if platform.system() == 'Darwin':
+                self.path = os.path.join(self.get_mac_default_config_folder(), 'config.ini')  # macOS下默认配置文件: ~/.mdcx/config.ini
+            else:
+                self.path = os.path.realpath('config.ini')  # 默认配置文件: 同目录下的 config.ini
             # 设置默认配置文件路径, 若存在则可读取, 否则生成默认配置文件
             with open(mdcx_config, 'w', encoding='UTF-8') as f:
                 f.write(self.path)


### PR DESCRIPTION
1. 修改了配置文件处理逻辑：默认配置文件目录为`~/.mdcx`，即macOS用户目录下的`.mdcx`，比如`/Users/name/.mdcx`。MDCx读取的`MDCx.config`固定在该目录下。配置文件目录一样可以修改，也建议用户修改，以后覆盖更新APP，不需要再设置配置文件目录。P.S. 这个修改只针对macOS系统。

2. `workflows/Release`是一个demo，毕竟不是我在维护mdcx，具体的自动化逻辑也劳烦作者去完善。