### PR TITLE
issue修复，日志输出优化

### DIFF
--- a/src/controllers/main_window/main_window.py
+++ b/src/controllers/main_window/main_window.py
@@ -150,10 +150,10 @@ class MyMAinWindow(QMainWindow):
         show_netstatus()  # 检查网络界面显示当前网络代理信息
         self.show_net_info(
             '\n💡 说明：\n '
-            '任意代理：javbus、jav321、javlibrary、mgstage、mywife、giga、freejavbt、'
+            '任意代理：javbus、jav321、javlibrary、mywife、giga、freejavbt、'
             'mdtv、madouqu、7mmtv、faleno、dahlia、prestige、theporndb、cnmdb、fantastica、kin8\n '
             '非日本代理：javdb、airav-cc、avsex（日本代理会报错）\n '
-            '日本代理：seesaawiki\n '
+            '日本代理：seesaawiki、mgstage\n '
             '无需代理：avsex、hdouban、iqqtv、airav-wiki、love6、lulubar、fc2、fc2club、fc2hub\n\n'
             '▶️ 点击右上角 【开始检测】按钮以测试网络连通性。')  # 检查网络界面显示提示信息
         signal.add_log("🍯 你可以点击左下角的图标来 显示 / 隐藏 请求信息面板！")
@@ -608,10 +608,10 @@ class MyMAinWindow(QMainWindow):
         self.Ui.stackedWidget.setCurrentIndex(1)
         self.set_left_button_style()
         self.Ui.pushButton_log.setStyleSheet('font-weight: bold; background-color: rgba(160,160,165,60);')
-        self.Ui.textBrowser_log_main.verticalScrollBar().setValue(
-            self.Ui.textBrowser_log_main.verticalScrollBar().maximum())
-        self.Ui.textBrowser_log_main_2.verticalScrollBar().setValue(
-            self.Ui.textBrowser_log_main_2.verticalScrollBar().maximum())
+        # self.Ui.textBrowser_log_main.verticalScrollBar().setValue(
+        #     self.Ui.textBrowser_log_main.verticalScrollBar().maximum())
+        # self.Ui.textBrowser_log_main_2.verticalScrollBar().setValue(
+        #     self.Ui.textBrowser_log_main_2.verticalScrollBar().maximum())
 
     # 点左侧的工具按钮
     def pushButton_tool_clicked(self):

--- a/src/models/base/web.py
+++ b/src/models/base/web.py
@@ -84,6 +84,13 @@ class WebRequests:
                 'Referer': 'https://www.javbus.com/',
             }
             headers.update(headers_o)
+        elif 'giga' in url:
+            # 搜索时需要携带refer，获取cookies时不能携带
+            giga_refer = '' if 'cookie_set.php' in url else 'https://www.giga-web.jp/top.html'
+            headers_o = {
+                'Referer': giga_refer,
+            }
+            headers.update(headers_o)
 
         signal.add_log(f'🔎 请求 {url}')
         for i in range(int(retry_times)):

--- a/src/models/base/web.py
+++ b/src/models/base/web.py
@@ -78,6 +78,12 @@ class WebRequests:
                 'referer': 'https://xcity.jp/result_published/?genre=%2Fresult_published%2F&q=2&sg=main&num=60',
             }
             headers.update(headers_o)
+        # javbus封面图需携带refer，refer似乎没有做强校验，但须符合格式要求，否则403
+        elif 'javbus' in url:
+            headers_o = {
+                'Referer': 'https://www.javbus.com/',
+            }
+            headers.update(headers_o)
 
         signal.add_log(f'🔎 请求 {url}')
         for i in range(int(retry_times)):
@@ -327,6 +333,7 @@ class WebRequests:
             except Exception as e:
                 error_info = '%s\nError: %s' % (url, e)
                 signal.add_log('[%s/%s] %s' % (i + 1, retry_times, error_info))
+                continue
         signal.add_log(f"🔴 请求失败！{error_info}")
         return False, error_info
 
@@ -367,11 +374,25 @@ def check_url(url, length=False, real_url=False):
             'Referer': 'http://www.getchu.com/top.html',
         }
         headers.update(headers_o)
+    # javbus封面图需携带refer，refer似乎没有做强校验，但须符合格式要求，否则403
+    elif 'javbus' in url:
+        headers_o = {
+            'Referer': 'https://www.javbus.com/',
+        }
+        headers.update(headers_o)
 
     for j in range(retry_times):
         try:
             r = requests.head(url, headers=headers, proxies=proxies, timeout=timeout, verify=False,
                               allow_redirects=True)
+            
+            # 不输出获取 dmm预览视频(trailer) 最高分辨率的测试结果到日志中
+            # get_dmm_trailer() 函数在多条错误的链接中找最高分辨率的链接，错误没有必要输出，避免误解为网络或软件问题
+            if r.status_code == 404 and '_w.mp4' in url:
+                if j + 1 < retry_times:
+                    continue
+                else:
+                    return 0
 
             # 状态码 > 299，表示请求失败，视为不可用
             if r.status_code > 299:
@@ -618,16 +639,16 @@ def get_imgsize(url):
     return 0, 0
 
 
-def get_dmm_trailer(trailer_url):  # 获取预览片
+def get_dmm_trailer(trailer_url):  # 如果预览片地址为 dmm ，尝试获取 dmm 预览片最高分辨率
     if '.dmm.co' not in trailer_url:
         return trailer_url
     if trailer_url.startswith('//'):
         trailer_url = 'https:' + trailer_url
     '''
-    '_sm_w.mp4': 320*180, 3.8MB
-    '_dm_w.mp4': 560*316, 10.1MB
-    '_dmb_w.mp4': 720*404, 14.6MB
-    '_mhb_w.mp4': 720*404, 27.9MB
+    '_sm_w.mp4': 320*180, 3.8MB     # 最低分辨率
+    '_dm_w.mp4': 560*316, 10.1MB    # 中等分辨率
+    '_dmb_w.mp4': 720*404, 14.6MB   # 次高分辨率
+    '_mhb_w.mp4': 720*404, 27.9MB   # 最高分辨率
     https://cc3001.dmm.co.jp/litevideo/freepv/s/ssi/ssis00090/ssis00090_sm_w.mp4
     https://cc3001.dmm.co.jp/litevideo/freepv/s/ssi/ssis00090/ssis00090_dm_w.mp4
     https://cc3001.dmm.co.jp/litevideo/freepv/s/ssi/ssis00090/ssis00090_dmb_w.mp4
@@ -642,6 +663,7 @@ def get_dmm_trailer(trailer_url):  # 获取预览片
             mhb_w = s + '_mhb_w.mp4'
             dmb_w = s + '_dmb_w.mp4'
             dm_w = s + '_dm_w.mp4'
+            # 次高分辨率只需检查最高
             if e == '_dmb_w.mp4':
                 if check_url(mhb_w):
                     trailer_url = mhb_w
@@ -650,6 +672,7 @@ def get_dmm_trailer(trailer_url):  # 获取预览片
                     trailer_url = mhb_w
                 elif check_url(dmb_w):
                     trailer_url = dmb_w
+            # 最差分辨率则依次检查最高，次高，中等
             elif e == '_sm_w.mp4':
                 if check_url(mhb_w):
                     trailer_url = mhb_w

--- a/src/models/core/scraper.py
+++ b/src/models/core/scraper.py
@@ -321,7 +321,7 @@ def _scrape_exec_thread(task):
         f'正在刮削： {Flags.scrape_started}/{count_all} {progress_percentage} \n {convert_path(file_show_path)}')
     signal.label_result.emit(f' 刮削中：{Flags.scrape_started - Flags.succ_count - Flags.fail_count} '
                              f'成功：{Flags.succ_count} 失败：{Flags.fail_count}')
-    json_data['logs'] += '\n' + '=' * 80
+    json_data['logs'] += '\n' + "👆" * 50
     json_data['logs'] += "\n 🙈 [Movie] " + convert_path(file_path)
     json_data['logs'] += "\n 🚘 [Number] " + movie_number
 
@@ -379,9 +379,10 @@ def _scrape_exec_thread(task):
             progress_value = count / count_all * 100
             progress_percentage = '%.2f' % progress_value + '%'
             used_time = get_used_time(start_time)
-            scrape_info_begin = '\n%d/%d (%s) round(%s) %s' % (
+            scrape_info_begin = '%d/%d (%s) round(%s) %s    新的刮削线程' % (
                 count, count_all, progress_percentage, Flags.count_claw, split_path(file_path)[1])
-            scrape_info_after = f'\n{"=" * 80}\n ' \
+            scrape_info_begin = '\n\n\n' + '👇'*50 + '\n' + scrape_info_begin
+            scrape_info_after = f'\n ' \
                                 f'🕷 {get_current_time()} {count}/{count_all} ' \
                                 f'{split_path(file_path)[1]} 刮削完成！用时 {used_time} 秒！'
             json_data['logs'] = scrape_info_begin + json_data['logs'] + scrape_info_after
@@ -607,6 +608,7 @@ def _check_stop(file_name_temp):
             f' 🕷 {get_current_time()} 已停止刮削：{Flags.now_kill}/{Flags.total_kills} {file_name_temp}')
         signal.set_label_file_path.emit(
             f'⛔️ 正在停止刮削...\n   正在停止已在运行的任务线程（{Flags.now_kill}/{Flags.total_kills}）...')
+        # exceptions must derive from BaseException
         raise '手动停止刮削'
 
 

--- a/src/models/crawlers/airav_cc.py
+++ b/src/models/crawlers/airav_cc.py
@@ -19,24 +19,28 @@ urllib3.disable_warnings()  # yapf: disable
 
 
 def get_web_number(html):
-    result = html.xpath('//p/span[contains(text(), "番號") or contains(text(), "番号")]/following-sibling::span/text()')
+    result = html.xpath('//*[contains(text(), "番號") or contains(text(), "番号")]//span/text()')
     return result[0].strip() if result else ''
 
 
 def get_number(html, number):
-    result = html.xpath('//p/span[contains(text(), "番號") or contains(text(), "番号")]/following-sibling::span/text()')
+    result = html.xpath('//*[contains(text(), "番號") or contains(text(), "番号")]//span/text()')
     num = result[0].strip() if result else ''
     return number if number else num
 
 
 def get_title(html):
-    result = html.xpath('//li[@class="vediotitle"]/h1/span/text()')
-    return result[0].strip() if result else ''
+    result = html.xpath('//div[@class="video-title my-3"]/h1/text()')
+    # 去除假的，无意义的标题(马赛克破坏版)，'克破'两字简繁同形
+    if result and '克破' not in str(result[0]):
+        return str(result[0]).strip()
+    else:
+        return ''
 
 
 def get_actor(html):
     try:
-        actor_list = html.xpath('//li[@class="allavgirls"]//a/text()')
+        actor_list = html.xpath('//*[contains(text(), "女優") or contains(text(), "女优")]//a/text()')
         result = ','.join(actor_list)
     except:
         result = ''
@@ -53,12 +57,12 @@ def get_actor_photo(actor):
 
 
 def get_studio(html):
-    result = html.xpath('//li[@class="series"]//a/text()')
+    result = html.xpath('//*[contains(text(), "廠商") or contains(text(), "厂商")]//a/text()')
     return result[0] if result else ''
 
 
 def get_release(html):
-    result = html.xpath('//span[@itemprop="datePublished"]/text()')
+    result = html.xpath('//i[@class="fa fa-clock me-2"]/../text()')
     if result:
         s = re.search(r'\d{4}-\d{2}-\d{2}', result[0]).group()
         return s if s else ''
@@ -74,18 +78,31 @@ def get_year(release):
 
 
 def get_tag(html):
-    result = html.xpath('//li[@class="keyword"]//a/text()')
+    result = html.xpath('//*[contains(text(), "標籤") or contains(text(), "标籤")]//a/text()')
     return ','.join(result) if result else ''
 
 
 def get_cover(html):
-    result = html.xpath('//div[@class="front-video-cover-img"]//img/@src')
-    return result[0] if result else ''
+    result = html.xpath('//script[@type="application/ld+json"]/text()')[0]
+    if result:
+        data_dict = json.loads(result)
+        result = data_dict.get("thumbnailUrl", "")[0]
+    return result if result else ''
 
 
 def get_outline(html):
-    result = html.xpath('//span[@itemprop="description"]/text()')
-    return result[0] if result else ''
+    result = html.xpath('//div[@class="video-info"]/p/text()')
+    result = result[0] if result else ''
+    # 去除假的，无意义的简介(马赛克破坏版)，'克破'两字简繁同形
+    if '克破' in str(result):
+        result = ''
+    return result
+
+
+def get_series(html):
+    result = html.xpath('//*[contains(text(), "系列")]//a/text()')
+    result = result[0] if result else ''
+    return result
 
 
 def retry_request(real_url, log_info, web_info):
@@ -109,6 +126,18 @@ def retry_request(real_url, log_info, web_info):
     tag = get_tag(html_info)
     studio = get_studio(html_info)
     return html_info, title, outline, actor, cover_url, tag, studio, log_info
+
+
+def get_real_url(html, number):
+    item_list = html.xpath('//div[@class="col oneVideo"]')
+    for each in item_list:
+        # href="/video?hid=99-21-39624"
+        detail_url = each.xpath('.//a/@href')[0]
+        title = each.xpath('.//h5/text()')[0]
+        # 注意去除马赛克破坏版这种几乎没有有效字段的条目
+        if number.upper() in title and '克破' not in title:
+            return detail_url
+    return ''
 
 
 def main(number, appoint_url='', log_info='', req_web='', language='zh_cn'):
@@ -136,8 +165,8 @@ def main(number, appoint_url='', log_info='', req_web='', language='zh_cn'):
     try:  # 捕获主动抛出的异常
         if not real_url:
 
-            # 通过搜索获取real_url https://airav5.fun/cn/searchresults.aspx?Search=ssis-200&Type=0
-            url_search = airav_url + f'/searchresults.aspx?Search={number}&Type=0'
+            # 通过搜索获取real_url https://airav.io/search_result?kw=ssis-200
+            url_search = airav_url + f'/search_result?kw={number}'
             debug_info = '搜索地址: %s ' % url_search
             log_info += web_info + debug_info
 
@@ -148,22 +177,27 @@ def main(number, appoint_url='', log_info='', req_web='', language='zh_cn'):
                 log_info += web_info + debug_info
                 raise Exception(debug_info)
             html = etree.fromstring(html_search, etree.HTMLParser())
-            number2 = ' ' + number.upper()
-            real_url = html.xpath(
-                "//h3[@class='one_name ga_name' and contains(text(), $number1) and not(contains(text(), '克破'))]/../@href",
-                number1=number2)
-
+            real_url = html.xpath('//div[@class="col oneVideo"]//h5[@]//a[@href]/@href')
             # if real_url:
             #     real_url = airav_url + '/' + real_url[0]
             # else:
+            # 没有搜索结果
             if not real_url:
                 debug_info = '搜索结果: 未匹配到番号！'
                 log_info += web_info + debug_info
                 raise Exception(debug_info)
 
         if real_url:
-            if isinstance(real_url, list) and real_url:
-                real_url = real_url[0]
+            # 只有一个搜索结果时直接取值 多个则进入判断
+            real_url = real_url[0] if len(real_url) == 1 else get_real_url(html, number)
+            # 搜索结果页面有条目，但无法匹配到番号
+            if not real_url:
+                debug_info = '搜索结果: 未匹配到番号！'
+                log_info += web_info + debug_info
+                raise Exception(debug_info)
+            else:
+                real_url = urllib.parse.urljoin(airav_url, real_url) if real_url.startswith("/") else real_url
+            
             debug_info = '番号地址: %s ' % real_url
             log_info += web_info + debug_info
             for i in range(3):
@@ -191,7 +225,7 @@ def main(number, appoint_url='', log_info='', req_web='', language='zh_cn'):
             year = get_year(release)
             runtime = ''
             score = ''
-            series = ''
+            series = get_series(html_info)
             director = ''
             publisher = ''
             extrafanart = ''
@@ -263,7 +297,7 @@ def main(number, appoint_url='', log_info='', req_web='', language='zh_cn'):
 
 if __name__ == '__main__':
     # yapf: disable
-    print(main('', 'https://airav.io/playon.aspx?hid=99-21-46640'))
+    # print(main('', 'https://airav.io/playon.aspx?hid=99-21-46640'))
     # print(main('PRED-300'))    # 马赛克破坏版
     # print(main('snis-036', language='jp'))
     # print(main('snis-036'))
@@ -297,3 +331,5 @@ if __name__ == '__main__':
     # print(main('S2M-055', ''))
     # print(main('LUXU-1217', ''))
     # print(main('x-art.19.11.03', ''))
+    # print(main('ssis-200', ''))     # 多个搜索结果
+    print(main('JUY-331', ''))      # 存在系列字段

--- a/src/models/crawlers/airav_cc.py
+++ b/src/models/crawlers/airav_cc.py
@@ -31,11 +31,11 @@ def get_number(html, number):
 
 def get_title(html):
     result = html.xpath('//div[@class="video-title my-3"]/h1/text()')
-    # 去除假的，无意义的标题(马赛克破坏版)，'克破'两字简繁同形
-    if result and '克破' not in str(result[0]):
-        return str(result[0]).strip()
-    else:
+    result = str(result[0]).strip() if result else ''
+    # 去掉无意义的简介(马赛克破坏版)，'克破'两字简繁同形
+    if not result or '克破' in result:
         return ''
+    return result
 
 
 def get_actor(html):
@@ -92,10 +92,13 @@ def get_cover(html):
 
 def get_outline(html):
     result = html.xpath('//div[@class="video-info"]/p/text()')
-    result = result[0] if result else ''
-    # 去除假的，无意义的简介(马赛克破坏版)，'克破'两字简繁同形
-    if '克破' in str(result):
-        result = ''
+    result = str(result[0]).strip() if result else ''
+    # 去掉无意义的简介(马赛克破坏版)，'克破'两字简繁同形
+    if not result or '克破' in result:
+        return ''
+    else:
+        # 去除简介中的无意义信息，中间和首尾的空白字符、*根据分发等
+        result = re.sub(r'[\n\t]', '', result).split('*根据分发', 1 )[0].strip()
     return result
 
 
@@ -177,7 +180,7 @@ def main(number, appoint_url='', log_info='', req_web='', language='zh_cn'):
                 log_info += web_info + debug_info
                 raise Exception(debug_info)
             html = etree.fromstring(html_search, etree.HTMLParser())
-            real_url = html.xpath('//div[@class="col oneVideo"]//h5[@]//a[@href]/@href')
+            real_url = html.xpath('//div[@class="col oneVideo"]//a[@href]/@href')
             # if real_url:
             #     real_url = airav_url + '/' + real_url[0]
             # else:
@@ -332,4 +335,5 @@ if __name__ == '__main__':
     # print(main('LUXU-1217', ''))
     # print(main('x-art.19.11.03', ''))
     # print(main('ssis-200', ''))     # 多个搜索结果
-    print(main('JUY-331', ''))      # 存在系列字段
+    # print(main('JUY-331', ''))      # 存在系列字段
+    print(main('SONE-248', ''))      # 简介存在无效信息  "*根据分发方式,内容可能会有所不同"

--- a/src/models/crawlers/iqqtv.py
+++ b/src/models/crawlers/iqqtv.py
@@ -14,12 +14,12 @@ urllib3.disable_warnings()  # yapf: disable
 
 
 def get_title(html):
-    result = html.xpath('//p[@class="movie_txt_nsme"]/text()')
-    if result:
-        result = result[0].strip()
+    result = html.xpath('//h1[@class="h4 b"]/text()')
+    # 去除假的，无意义的标题(马赛克破坏版)，'克破'两字简繁同形
+    if result and '克破' not in str(result[0]):
+        return str(result[0]).strip()
     else:
-        result = ''
-    return result
+        return ''
 
 
 def get_real_title(title):
@@ -41,10 +41,8 @@ def getWebNumber(title, number):
 
 
 def getActor(html):
-    try:
-        result = str(html.xpath('//p[@class="movie_txt_av"]/a/span/text()')).strip("['']").replace("'", '')
-    except:
-        result = ''
+    actor_list = html.xpath('//a[contains(@href, "actor")]/span/text()')
+    result = ','.join(actor_list) if actor_list else ""
     return result
 
 
@@ -58,7 +56,7 @@ def getActorPhoto(actor):
 
 
 def getCover(html):
-    result = html.xpath('//p[@id="mv_img"]/img/@src')
+    result = html.xpath('//meta[@property="og:image"]/@content')
     if result:
         result = result[0]
     else:
@@ -67,16 +65,20 @@ def getCover(html):
 
 
 def getOutline(html):
-    result = html.xpath('//p[@itemprop="description"]/span/text()')
-    if result:
-        result = result[0].strip()
+    result = html.xpath('//p[contains(., "简介")]/text()')
+    # 去除假的，无意义的简介(马赛克破坏版)，'克破'两字简繁同形
+    if result and '克破' not in str(result[0]):
+        # 去除中间和首尾的空白字符
+        result = result[0].strip().replace('\n', '').replace('\t', '')
+        # 去除简介二字
+        result = result.replace('簡介：', '').replace('简介：', '').strip()
     else:
         result = ''
     return result
 
 
 def getRelease(html):
-    result = html.xpath('//p[@itemprop="datePublished"]/text()')
+    result = html.xpath('//div[@class="date"]/text()')
     if result:
         result = result[0].replace('/', '-').strip()
     else:
@@ -93,9 +95,9 @@ def getYear(release):
 
 
 def getTag(html):
-    result = html.xpath('//p[@class="movie_txt_tag"]/a/text()')
-    if result:
-        result = str(result).strip(" ['']").replace("'", "").replace(', ', ',')
+    tag_list = html.xpath('//div[contains(@class,"tag-info")]//a[contains(@href, "tag")]/text()')
+    if tag_list:
+        result = ','.join(tag_list) if tag_list else ""
     else:
         result = ''
     return result
@@ -110,7 +112,7 @@ def getMosaic(tag):
 
 
 def getStudio(html):
-    result = html.xpath('//p[@class="movie_txt_fac"]/a/span/text()')
+    result = html.xpath('//a[contains(@href, "fac")]/div[@itemprop]/text()')
     if result:
         result = result[0].strip()
     else:
@@ -127,6 +129,33 @@ def getRuntime(html):
     else:
         result = ''
     return str(result)
+
+
+def get_series(html):
+    result = html.xpath('//a[contains(@href, "series")]/text()')
+    result = result[0] if result else ''
+    return result
+
+
+def get_extrafanart(html):
+    extrafanart_list = html.xpath('//div[@class="cover"]//img[@src]/@data-src')
+    return extrafanart_list
+
+
+def get_real_url(html, number):
+    number = number.replace('FC2', '').replace('-PPV', '')
+    # 非 fc2 影片前面加入空格，可能会导致识别率降低
+    # if not re.search(r'\d+[-_]\d+', number):
+    #     number1 = ' ' + number.replace('FC2', '').replace('-PPV', '')
+    item_list = html.xpath('//span[@class="title"]')
+    for each in item_list:
+        detail_url = each.xpath('./a/@href')[0]
+        title = each.xpath('./a/@title')[0]
+        # 注意去除马赛克破坏版等几乎没有有效字段的条目
+        for i in ['克破', '无码流出', '無碼流出']:
+            if number.upper() in title and i not in title:
+                return detail_url
+    return ''
 
 
 def main(number, appoint_url='', log_info='', req_web='', language='zh_cn'):
@@ -169,13 +198,7 @@ def main(number, appoint_url='', log_info='', req_web='', language='zh_cn'):
                 log_info += web_info + debug_info
                 raise Exception(debug_info)
             html = etree.fromstring(html_search, etree.HTMLParser())
-            number1 = number.replace('FC2', '').replace('-PPV', '')
-            if not re.search(r'\d+[-_]\d+', number):
-                number1 = ' ' + number.replace('FC2', '').replace('-PPV', '')
-            real_url = html.xpath(
-                "//h3[@class='one_name ga_name' and (contains(text(), $number)) and not (contains(text(), '克破')) and not (contains(text(), '无码流出')) and not (contains(text(), '無碼流出')) and not (contains(text(), '無修正'))]/../@href",
-                number=number1)
-
+            real_url = html.xpath('//a[@class="ga_click"]/@href')
             if real_url:
                 real_url = iqqtv_url + real_url[0].replace('/cn/', '').replace('/jp/', '').replace('&cat=19', '')
             else:
@@ -183,6 +206,12 @@ def main(number, appoint_url='', log_info='', req_web='', language='zh_cn'):
                 log_info += web_info + debug_info
                 raise Exception(debug_info)
         if real_url:
+            # 只有一个搜索结果时直接取值 多个则进入判断
+            if len(real_url) == 1:
+                real_url = iqqtv_url + real_url[0].replace('/cn/', '').replace('/jp/', '').replace('&cat=19', '')
+            else:
+                real_url_tmp =  get_real_url(html, number)
+                real_url = iqqtv_url + real_url_tmp.replace('/cn/', '').replace('/jp/', '').replace('&cat=19', '')
             debug_info = '番号地址: %s ' % real_url
             log_info += web_info + debug_info
             result, html_content = get_html(real_url)
@@ -211,12 +240,12 @@ def main(number, appoint_url='', log_info='', req_web='', language='zh_cn'):
             if mosaic == '无码':
                 image_cut = 'center'
             studio = getStudio(html_info)
-            runtime = getRuntime(html_info)
+            runtime = ''
             score = ''
-            series = ''
+            series = get_series(html_info)
             director = ''
             publisher = studio
-            extrafanart = ''
+            extrafanart = get_extrafanart(html_info)
             tag = tag.replace('无码片', '').replace('無碼片', '').replace('無修正', '')
             try:
                 dic = {
@@ -287,7 +316,7 @@ if __name__ == '__main__':
     # print(main('gs-067'))
     # print(main('110912-179'))
     # print(main('abs-141'))
-    print(main('FC2-906625'))
+    # print(main('FC2-906625'))
     # print(main('HYSD-00083'))
     # print(main('IESP-660'))
     # print(main('n1403'))
@@ -313,3 +342,5 @@ if __name__ == '__main__':
     # print(main('032020-001', ''))
     # print(main('S2M-055', ''))
     # print(main('LUXU-1217', ''))
+    # print(main('aldn-334', ''))           # 存在系列字段
+    print(main('ssni-200', ''))           # 存在多个搜索结果

--- a/src/models/crawlers/iqqtv.py
+++ b/src/models/crawlers/iqqtv.py
@@ -15,11 +15,11 @@ urllib3.disable_warnings()  # yapf: disable
 
 def get_title(html):
     result = html.xpath('//h1[@class="h4 b"]/text()')
-    # 去除假的，无意义的标题(马赛克破坏版)，'克破'两字简繁同形
-    if result and '克破' not in str(result[0]):
-        return str(result[0]).strip()
-    else:
+    result = str(result[0]).strip() if result else ''
+    # 去掉无意义的简介(马赛克破坏版)，'克破'两字简繁同形
+    if not result or '克破' in result:
         return ''
+    return result
 
 
 def get_real_title(title):
@@ -65,15 +65,14 @@ def getCover(html):
 
 
 def getOutline(html):
-    result = html.xpath('//p[contains(., "简介")]/text()')
-    # 去除假的，无意义的简介(马赛克破坏版)，'克破'两字简繁同形
-    if result and '克破' not in str(result[0]):
-        # 去除中间和首尾的空白字符
-        result = result[0].strip().replace('\n', '').replace('\t', '')
-        # 去除简介二字
-        result = result.replace('簡介：', '').replace('简介：', '').strip()
+    result = html.xpath('//p[contains(., "简介") or contains(., "簡介")]/text()')
+    result = str(result[0]).strip() if result else ''
+    # 去掉无意义的简介(马赛克破坏版)，'克破'两字简繁同形
+    if not result or '克破' in result:
+        return ''
     else:
-        result = ''
+        # 去除简介中的无意义信息，中间和首尾的空白字符、简介两字、*根据分发等
+        result = re.sub(r'[\n\t]|(简|簡)介：', '', result).split('*根据分发', 1 )[0].strip()
     return result
 
 
@@ -343,4 +342,5 @@ if __name__ == '__main__':
     # print(main('S2M-055', ''))
     # print(main('LUXU-1217', ''))
     # print(main('aldn-334', ''))           # 存在系列字段
-    print(main('ssni-200', ''))           # 存在多个搜索结果
+    # print(main('ssni-200', ''))           # 存在多个搜索结果
+    print(main('START-104', ''))      # 简介存在无效信息  "*根据分发方式,内容可能会有所不同"

--- a/src/models/crawlers/jav321.py
+++ b/src/models/crawlers/jav321.py
@@ -106,7 +106,8 @@ def getTag(response):  # 获取演员
 
 
 def getOutline(detail_page):
-    return detail_page.xpath("string(/html/body/div[2]/div[1]/div[1]/div[2]/div[3]/div)")
+    # 修复路径，避免简介含有垃圾信息 "*根据分发方式，内容可能会有所不同”
+    return detail_page.xpath("string(/html/body/div[2]/div[1]/div[1]/div[2]/div[3]/div/text())")
 
 
 def main(number, appoint_url='', log_info='', req_web='', language='jp'):
@@ -244,7 +245,7 @@ def main(number, appoint_url='', log_info='', req_web='', language='jp'):
 
 if __name__ == '__main__':
     # print(main('blk-495'))
-    print(main('hkgl-004'))
+    # print(main('hkgl-004'))
     # print(main('snis-333'))
     # print(main('GERK-326'))
     # print(main('msfh-010'))
@@ -258,3 +259,4 @@ if __name__ == '__main__':
     # print(main('ABP-905'))
     # print(main('heyzo-1031', ''))
     # print(main('ymdd-173', 'https://www.jav321.com/video/ymdd00173'))
+    print(main('MIST-409'))


### PR DESCRIPTION
### 修复
- 修复 #212 
- 修复 #216 
- 修复 #222 
- 修复 avsex，avsex已经改名了，我不清楚以前叫什么名字，现在叫av大平台，如果还保留avsex名字会造成困惑，作者自己改个名字吧，爬虫以及网络日志等都要改名
- 修改日志输出，去除不必要的有误导性的日志
### 已知问题&说明
- 目前 最重要的两个网站 javbus 和 javdb 都开启了访问频率限制，太快的访问速度必定 **429 或 404**，大量刮削时一定会出问题，但代理池这种东西不仅对用户来说使用成本比较高，而且工作量也极大，所以 **403** 被限制甚至 **404** 被封IP的，自己降低线程数和间歇刮削数，推荐**15个间隔1分半左右**
- 其他网站包括翻译接口，都有 **429** 错误，暂时没有方案进展
- 文档比较欠缺，尤其是配置文件许久未更新，好的配置文件能避免很多错误以及获得效率信息最大化，之后有空另提PR
- 这个软件给人一种庞大的感觉，总是想一个软件解决所有问题，所以有无数的业务逻辑，比如判断番号类型，实际上多种类型的番号放在一起，很难不出错，最好的方法还是不同的番号切换不同的配置文件，由用户自己判断选择要刮削的番号类型，能避免很多问题，所以预置的配置文件很重要，足够了解这个软件以及各种网站特点的人才能编写出合适的配置文件，我再积累积累经验