### PR TITLE
重新修复wiki字段

### DIFF
--- a/src/models/tools/emby_actor_info.py
+++ b/src/models/tools/emby_actor_info.py
@@ -292,7 +292,7 @@ def _get_wiki_detail(url, url_log, actor_info: EMbyActressInfo):
         signal.show_log_text(" 🔴 页面内容未命中关键词，识别为非女优或导演！")
         return False
 
-    res = re.sub(r'\[\d+\]', '', res)  # 替换[1],[2]等注释
+    res = re.sub(r'<a href=\"#cite_note.*?</a>', '', res)  # 替换[1],[2]等注释
     soup = bs4.BeautifulSoup(res, 'lxml')
     actor_output = soup.find(class_='mw-parser-output')
 
@@ -309,7 +309,7 @@ def _get_wiki_detail(url, url_log, actor_info: EMbyActressInfo):
     actor_profile = actor_output.find(name='table', class_=['infobox', 'infobox vcard plainlist'])
     if actor_profile:
         att_keys = actor_profile.find_all(scope=["row"])
-        att_values = actor_profile.find_all(name='td', style=[''], class_=['infobox-data', 'infobox-data org'])
+        att_values = actor_profile.find_all(name='td', style=[''], colspan=False)
         bday = actor_output.find(class_='bday')
         bday = '(%s)' % bday.get_text('', strip=True) if bday else ''
         if att_keys and att_values:


### PR DESCRIPTION
之前提出的wiki字段修改有问题, 当时只关注了中文wiki, 而日文wiki的页面结构是不同的. 当前的过滤规则无法获取到日文wiki的个人资料信息, 本次对此重新进行了修复.
此外, 源码中对于注释角标的过滤也存在问题, 此次一并修复.
代码已在本地进行测试, 结果符合预期.
测试结果:
1. 个人资料获取
当前版本: 日文wiki无个人资料
![屏幕截图 2024-09-11 124753](https://github.com/user-attachments/assets/3cdecc46-8a79-44df-ac75-0a11cec4cde9)
测试版本: 
![屏幕截图 2024-09-11 151246](https://github.com/user-attachments/assets/b558b6b0-712a-428c-8d39-846e445a3eb5)

2. 注释角标过滤
当前版本: 
![屏幕截图 2024-09-11 124817](https://github.com/user-attachments/assets/1b997b4d-0ef9-4d4f-a7d7-1388c10cbbdf)
测试版本:
![屏幕截图 2024-09-11 151326](https://github.com/user-attachments/assets/f9576da0-e5e3-4a0f-96bf-004489eb4cdb)