### PR TITLE
update dmm xpath, optimize amazon image download process.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         uses: dev-drprasad/delete-tag-and-release@v1.1
         if: ${{ env.IS_DAILY == 'true' && steps.get-new-commits.outputs.count > 0  }}
         with:
-          tag_name: daily_release
+          tag_name: mdcx-v1.0
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       # https://github.com/actions/runner/issues/1985#issuecomment-1573518052
@@ -166,7 +166,7 @@ jobs:
           prerelease: ${{ env.IS_DAILY }}
           body: |
             ${{ env.IS_DAILY=='true' && github.event.repository.updated_at || steps.get-changelog.outputs.CHANGELOG }}
-          tag: ${{ env.IS_DAILY=='true' && 'daily_release' || github.ref }}
+          tag: ${{ env.IS_DAILY=='true' && 'mdcx-v1.0' || github.ref }}
 
       - name: Create Release - Windows
         uses: svenstaro/upload-release-action@2.7.0
@@ -176,4 +176,4 @@ jobs:
           asset_name: MDCx-$tag-${{ matrix.build }}-${{ matrix.arch }}${{ matrix.tail }}-${{ needs.init-matrix.outputs.short_sha }}.exe
           file: dist/MDCx.exe
           prerelease: ${{ env.IS_DAILY }}
-          tag: ${{ env.IS_DAILY=='true' && 'daily_release' || github.ref }}
+          tag: ${{ env.IS_DAILY=='true' && 'mdcx-v1.0' || github.ref }}

--- a/src/models/base/web.py
+++ b/src/models/base/web.py
@@ -562,7 +562,7 @@ def get_avsox_domain():
 
 def get_amazon_data(req_url):
     """
-    获取 Amazon 数据，修改地区为540-0002
+    获取 Amazon 数据
     """
     headers = {
         "accept-encoding": "gzip, deflate, br",
@@ -595,70 +595,6 @@ def get_amazon_data(req_url):
 
         if not result:
             return False, html_info
-
-    if "540-0002" not in html_info:
-        try:
-            # 获取 anti_csrftoken_a2z
-            anti_csrftoken_a2z = re.findall(r"anti-csrftoken-a2z([^}]+)", html_info)[0].replace("&quot;", "").strip(":")
-            session_id = re.findall(r'sessionId: "([^"]+)', html_info)[0]
-            ubid_acbjp = ""
-            if "ubid-acbjp" in str(result):
-                try:
-                    ubid_acbjp = result["set-cookie"]
-                except:
-                    try:
-                        ubid_acbjp = re.findall(r"ubid-acbjp=([^ ]+)", str(result))[0]
-                    except:
-                        pass
-            headers_o = {
-                "Anti-csrftoken-a2z": anti_csrftoken_a2z,
-                "cookie": f"session-id={session_id}; ubid_acbjp={ubid_acbjp}",
-            }
-            headers.update(headers_o)
-            mid_url = (
-                "https://www.amazon.co.jp/portal-migration/hz/glow/get-rendered-toaster"
-                "?pageType=Search&aisTransitionState=in&rancorLocationSource=REALM_DEFAULT&_="
-            )
-            result, html = curl_html(mid_url, headers=headers)
-            try:
-                anti_csrftoken_a2z = re.findall(r'csrfToken="([^"]+)', html)[0]
-                ubid_acbjp = re.findall(r"ubid-acbjp=([^ ]+)", str(result))[0]
-            except:
-                pass
-
-            # 修改配送地址为日本，这样结果多一些
-            headers_o = {
-                "Anti-csrftoken-a2z": anti_csrftoken_a2z,
-                "Content-length": "140",
-                "Content-Type": "application/json",
-                "cookie": f"session-id={session_id}; ubid_acbjp={ubid_acbjp}",
-            }
-            headers.update(headers_o)
-            post_url = "https://www.amazon.co.jp/portal-migration/hz/glow/address-change?actionSource=glow"
-            data = {
-                "locationType": "LOCATION_INPUT",
-                "zipCode": "540-0002",
-                "storeContext": "generic",
-                "deviceType": "web",
-                "pageType": "Search",
-                "actionSource": "glow",
-            }
-            result, html = post_html(post_url, json=data, headers=headers)
-            if result:
-                if "540-0002" in str(html):
-                    headers = {
-                        "Host": "www.amazon.co.jp",
-                        "User-Agent": get_user_agent(),
-                    }
-                    result, html_info = curl_html(req_url, headers=headers)
-                else:
-                    print("Amazon 修改地区失败: ", req_url, str(result), str(html))
-            else:
-                print("Amazon 修改地区异常: ", req_url, str(result), str(html))
-
-        except Exception as e:
-            print("Amazon 修改地区出错: ", req_url, str(e))
-            print(traceback.format_exc())
 
     return result, html_info
 

--- a/src/models/crawlers/dmm.py
+++ b/src/models/crawlers/dmm.py
@@ -98,9 +98,11 @@ def get_tag(html):
 
 
 def get_cover(html):
-    result = html.xpath('//a[@name="package-image"]/@href')
-    result = re.sub(r"pics.dmm.co.jp", r"awsimgsrc.dmm.co.jp/pics_dig", result[0])
-    return result if result else ""
+    result = html.xpath('//a[@id="sample-image1"]/img/@src')
+    if result:
+        # 替换域名并返回第一个匹配项
+        return re.sub(r'pics.dmm.co.jp', r'awsimgsrc.dmm.co.jp/pics_dig', result[0])
+    return ''  # 无匹配时返回空字符串
 
 
 def get_poster(html, cover):


### PR DESCRIPTION
### **更新**: 最新分支: https://github.com/sqzw-x/mdcx/pull/356 在此基础进行了更新, 这个分支不小心改了release.yml, 请以最新分支为准. 

-------------------------------------------------------------------------------------------------------------------------
### **此分支修复了无法获取dmm网站信息的问题, 优化了Amazon下载图片的流程.**

### **关于dmm网站**
dmm网页有变更, 更改了获取图片url的xpath.

### **关于Amazon图片下载**
下载Amazon官网图片时, 脚本会以修改邮编的方式将Amazon地区改为日本大阪(540-0002), 以此来获取日本当地的搜索结果, 因为如果地区为日本国外, 是搜不到影片的.
但是经过测试, 目前修改地址的方法已经失效, 以下列出各种情况:

1. 使用非日本代理, 可以修改Amazon地区为日本, 但是仍无法下载Amazon官网图片, 此处原因未深究.
2. 使用日本代理, 但是脚本只是根据返回的html信息中是否包含540-0002来判断IP所在地, 如果不包含则依然会进行修改. 
    修改时会在请求信息中添加540-0002, 然而只要使用日本代理, 这个修改是不会成功的, 即返回的html信息不包含540-0002.

     - 先使用post方法尝试, 如果有返回信息则判断是否包含540-0002(_肯定不会有_), 有的话则更换为curl方法请求(_不可能发生_). 不过即使如此, 因为返回值为true, 脚本依然会使用更改地址前的html信息来下载Amazon图片.
    - post有一定概率失败, 如果重复预设次数后仍失败, 则返回false, 脚本会根据返回值弃用Amazon的 html 信息.

       

      > 注: 此处就是为什么明明日志里面的url打开后, Amazon能显示结果却无法下载图片的原因. 因为即使能获取有效信息, 只要里面没有540-0002, 脚本就会继续修改地址, 当post方法失败后, 整个Amazon信息就会被丢弃.


**修改方案:**
简单粗暴, 删除修改Amazon地区的代码, 目前来看只会增加请求时间, 去除有效信息, 没有任何积极作用.

**总之一句话, 想下载Amazon图片, 挂日本代理才是王道!**
带来的副作用: 一些网站会屏蔽日本IP, 例如javdb, airav_cc(AV大平台)等, 推荐使用代理分流, 能够完美解决.
另外因为Amazon是搜标题而不是番号, 而标题来源网站的内容和Amazon会有差异, 虽然脚本会通过截断标题, 转换屏蔽词来搜索, 但是无法保证100%成功.
其实现在dmm的新片2K封面清晰度已经很高了, 虽然从分辨率上看不如Amazon, 但分辨率和清晰度并非正相关. 我的笔记本屏幕是4K, 全屏放大是看不出区别的, 至于大屏电视的显示效果没有测试. 反而有时dmm的图片会比Amazon清晰, 而且现在的新片Amazon也直接开始用dmm的图片了, 所以不必太纠结这个, 一般也就刮老片会用.

**建议**
是否可以恢复版本迭代? 一是目前版本已趋于稳定, 更新频次降低; 二是每日构建会覆盖之前的版本, 有时候新的发布因为某些原因导致脚本无法使用, 但是无法回退版本, 只能等待修复, 会耽误使用.