### PR TITLE
fix: 对 Windows 网络路径进行修改.

### DIFF
--- a/src/models/core/utils.py
+++ b/src/models/core/utils.py
@@ -68,6 +68,10 @@ def get_video_size(json_data, file_path):
     if os.path.islink(file_path):
         if "symlink_definition" in config.no_escape:
             file_path = read_link(file_path)
+
+            # Windows 系统指向 CloudDrive2 等网络挂载路径的链接，会带有前缀 \\?
+            if file_path.startswith('\\\\?'):
+                file_path = file_path[3:]
         else:
             hd_get = "path"
     if hd_get == "video":


### PR DESCRIPTION
不去掉前缀无法进行分辨率识别。

## 网络挂载常规操作

#346 

- 在 Windows 上使用 CloudDrive2 进行云盘挂载，只用来存储视频文件。
- MDCx 使用指向 CloudDrive2 路径的软链接进行刮削。
- Jellyfin/Emby 使用指向 CloudDrive2 路径的软链接构建播放对象。

考虑到很多 MDCx 用户使用 Windows 系统，有必要对 Windows 软链接特性做优化。

通过 PowerShell 命令

```
New-Item -ItemType SymbolicLink -Path ABF-200-C.mp4 -Target J:\ABF-200-C.mp4
```

创建软链接，也不能识别分辨率。经过调试发现是 `os.readlink()` 的结果不能被 OpenCV 正确处理，去除前缀之后即可正常运行。