### PR TITLE
fix: 当配置值含有百分号时保存处理导致应用崩溃和配置被重置的问题

### DIFF
--- a/src/models/config/manager.py
+++ b/src/models/config/manager.py
@@ -41,7 +41,7 @@ class ConfigManager(ManualConfig):
             f.write(self.format_ini(self.config))
 
     def _read_file(self, path):
-        reader = RawConfigParser()
+        reader = RawConfigParser(interpolation=None)
         reader.read(path, encoding="UTF-8")
         field_types = {f.name: f.type for f in fields(ConfigSchema)}
         errors = []
@@ -92,7 +92,7 @@ class ConfigManager(ManualConfig):
     @staticmethod
     def format_ini(cfg: "ConfigSchema"):
         buffer = StringIO()
-        parser = ConfigParser()
+        parser = ConfigParser(interpolation=None)
         parser.add_section("mdcx")
         for field in fields(cfg):
             value = getattr(cfg, field.name)


### PR DESCRIPTION
https://github.com/sqzw-x/mdcx/issues/445
https://github.com/sqzw-x/mdcx/issues/426
https://github.com/sqzw-x/mdcx/issues/425

[configparser - 值的插值](https://docs.python.org/zh-cn/3.13/library/configparser.html#interpolation-of-values)

@sqzw-x 请review和测试