### PR TITLE
fix: 修正 deepl_translate_async 參數數量錯誤及型別檢查 (#483)

### DIFF
--- a/src/models/core/translate.py
+++ b/src/models/core/translate.py
@@ -353,7 +353,7 @@ async def translate_actor(json_data: JsonData):
         if each_actor:
             actor_data = resources.get_actor_data(each_actor)
             new_actor = actor_data.get(actor_language)
-            if not REGEX_KANA.search(new_actor):
+            if new_actor and not REGEX_KANA.search(new_actor):
                 if actor_language == "zh_cn":
                     new_actor = zhconv.convert(new_actor, "zh-cn")
                 elif actor_language == "zh_tw":
@@ -441,7 +441,7 @@ async def translate_title_outline(json_data: JsonData, movie_number: str):
                 elif each == "llm":  # 使用 llm 翻译
                     t, o, r = await llm_translate_async(trans_title, trans_outline)
                 else:  # 使用deepl翻译
-                    t, o, r = await deepl_translate_async(trans_title, trans_outline, "JA", json_data)
+                    t, o, r = await deepl_translate_async(trans_title, trans_outline, "JA")
                 if r:
                     LogBuffer.log().write(
                         f"\n 🔴 Translation failed!({each.capitalize()})({get_used_time(start_time)}s) Error: {r}"


### PR DESCRIPTION
- 修正 translate_title_outline 内部呼叫 deepl_translate_async 传递 4 个参数，改为正确的 3 个参数，避免 TypeError。
- 修正 REGEX_KANA.search 可能传入 None 的问题，增加 None 检查，避免型别错误。