### PR TITLE
fix: TypeError: a bytes-like object is required, not 'coroutine' (#490)

### DIFF
--- a/src/models/base/web.py
+++ b/src/models/base/web.py
@@ -149,22 +149,26 @@ async def get_amazon_data(req_url: str) -> Tuple[bool, str]:
 
 
 async def get_imgsize(url) -> tuple[int, int]:
-    response, err = await config.async_client.request("GET", url, stream=True)
+    response, _ = await config.async_client.request("GET", url, stream=True)
     if response is None or response.status_code != 200:
         return 0, 0
     file_head = BytesIO()
     chunk_size = 1024 * 10
-    for chunk in response.iter_content(chunk_size):
-        file_head.write(chunk)
+    try:
+        for chunk in response.iter_content(chunk_size):
+            file_head.write(await chunk)
+            try:
+                def _get_size():
+                    return Image.open(file_head).size
+                return await asyncio.to_thread(_get_size)
+            except Exception:
+                # 如果解析失败，继续下载更多数据
+                continue
+    except Exception:
+        return 0, 0
+    finally:
         response.close()
-        try:
 
-            def _get_size():
-                return Image.open(file_head).size
-
-            await asyncio.to_thread(_get_size)
-        except Exception:
-            return 0, 0
     return 0, 0
 
 


### PR DESCRIPTION
修正 get_imgsize 函數在處理圖片流時，因誤用 chunk 導致 TypeError: a bytes-like object is required, not 'coroutine'

- 原因：curl_cffi 的 iter_content 回傳的是生成器，每個 chunk 是 coroutine，需 await 取得 bytes。
- 修正：for 迴圈遍歷 chunk，對每個 chunk 使用 await，確保寫入 BytesIO 的是 bytes。
- 保持原有設計：只下載圖片頭部資料以獲取尺寸，避免整張大圖下載。