### PR TITLE
更新: 使用dmm.jp 的数据修正mapping_info.xml

### DIFF
--- a/resources/mapping_table/mapping_info.xml
+++ b/resources/mapping_table/mapping_info.xml
@@ -1,354 +1,461 @@
-<?xml version='1.0' encoding='utf-8'?>
-<info>
-      <!-- 说明：可使用文本编辑器打开本文件后自行编辑。
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- 说明：可使用文本编辑器打开本文件后自行编辑。
 keyword：用于匹配标签/导演/系列/制作/发行的关键词，每个名字前后都需要用逗号隔开。当其中包含刮削得到的关键词时，可以输出对应语言的词。
 zh_cn/zh_tw/jp：指对应语言输出的词，按设置的对应语言输出。当输出词为“删除”时表示：遇到该关键词时，在对应内容中删除该关键词-->
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",成人奖," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",觸摸打字,触摸打字," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",10枚組," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",Don Cipote's choice," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",DVD多士爐," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",R-18," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",Vシネマ," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",イメージビデオ（男性）," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",サンプル動画," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",其他," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",放置," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",獨立製作,独立制作,独占配信,配信専用," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",特典あり（AVベースボール）," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",天堂TV," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",性愛," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",限時降價," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",亞洲女演員,亚洲女演员," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",字幕,中文字幕,中文," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",AV女优,女优," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",HDTV,HD DVD," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",MicroSD," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",R-15," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",UMD," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",VHS," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",愛好，文化,爱好、文化," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",訪問,访问," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",感官作品," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",高畫質," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",高清," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",素人作品," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",友誼,友谊," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",正常," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",蓝光," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",冒險,冒险," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",模擬,模拟," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",年輕女孩,年轻女孩," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",去背影片," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",天賦,天赋," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",形象俱樂部,形象俱乐部," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",懸疑,悬疑," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",亞洲,亚洲," />
-      <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",ハロウィーンキャンペーン," />
+<info>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",成人奖,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",觸摸打字,触摸打字,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",10枚組,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",Don Cipote's choice,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",DVD多士爐,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",R-18,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",Vシネマ,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",イメージビデオ,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",イメージビデオ（男性）,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",サンプル動画,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",其他,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",獨立製作,独立制作,独占配信,配信専用,インディーズ,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",特典あり（AVベースボール）,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",天堂TV,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",性愛,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",限時降價,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",亞洲女演員,亚洲女演员,アジア女優,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",字幕,中文字幕,中文,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",AV女优,女优,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",HDTV,HD DVD,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",MicroSD,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",R-15,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",UMD,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",VHS,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",復刻,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",愛好，文化,爱好、文化,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",訪問,访问,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",感官作品,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",高畫質,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",高清,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",素人作品,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",友誼,友谊,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",正常,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",蓝光,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",冒險,冒险,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",模擬,模拟,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",去背影片,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",天賦,天赋,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",形象俱樂部,形象俱乐部,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",懸疑,悬疑,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",亞洲,亚洲,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",ハロウィーンキャンペーン,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",ハイビジョン,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",セット商品,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",その他,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",デジモ,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",數位馬賽克,数位马赛克,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",FANZA配信限定,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",複数話,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",福袋,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",すべてのセール,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",日替わりセール！,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",みんなのお気に入り30％OFF第1弾,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",エスワンキャンペーン30％OFF第12弾,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",SODグループ30％OFF第2弾,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",ディープス他30％OFF,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",そ妄想族30％OFF第2弾,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",桃太郎映像出版30％OFF,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",ブランドストア30％OFF☆,"/>
+    <a zh_cn="删除" zh_tw="删除" jp="删除" keyword=",期間限定セール,"/>
 
-      <a zh_cn="16小时+" zh_tw="16小時+" jp="16時間以上作品" keyword=",16小時以上作品,16小时以上作品,16時間以上作品,16小时+,16小時+," />
-      <a zh_cn="3D卡通" zh_tw="3D卡通" jp="3Dエロアニメ" keyword=",3D卡通,3Dエロアニメ," />
-      <a zh_cn="DMM独家" zh_tw="DMM獨家" jp="DMM獨家" keyword=",DMM獨家,DMM独家,DMM專屬,DMM专属," />
-      <a zh_cn="轻虐" zh_tw="輕虐" jp="微SM" keyword=",微SM,轻虐,輕虐," />
-      <a zh_cn="VR" zh_tw="VR" jp="VR" keyword=",VR,VR専用,高品质VR,ハイクオリティVR," />
-      <a zh_cn="武术格斗" zh_tw="武術格鬥" jp="アクション" keyword=",格鬥家,格斗家,戰鬥行動,战斗行动,アクション,武术格斗,武術格鬥," />
-      <a zh_cn="绝顶高潮" zh_tw="絕頂高潮" jp="アクメ・オーガズム" keyword=",极致·性高潮,アクメ・オーガズム,绝顶高潮,絕頂高潮," />
-      <a zh_cn="运动" zh_tw="運動" jp="アスリート" keyword=",运动员,アスリート,運動,运动," />
-      <a zh_cn="COSPLAY" zh_tw="COSPLAY" jp="COSPLAY" keyword=",COSPLAY,COSPLAY服飾,COSPLAY服饰,アニメ," />
-      <a zh_cn="动画角色" zh_tw="動畫角色" jp="動畫人物" keyword=",动漫,動画,動畫人物,动画人物,动画角色,動畫角色," />
-      <a zh_cn="角色扮演" zh_tw="角色扮演" jp="角色扮演" keyword=",角色扮演者,角色扮演,コスプレ," />
-      <a zh_cn="萝莉Cos" zh_tw="蘿莉Cos" jp="蘿莉Cos" keyword=",蘿莉角色扮演,萝莉角色扮演,萝莉Cos,蘿莉Cos," />
-      <a zh_cn="纯欲" zh_tw="純欲" jp="エロス" keyword=",エロス,纯欲,純欲," />
-      <a zh_cn="御宅族" zh_tw="御宅族" jp="オタク" keyword=",御宅族,オタク," />
-      <a zh_cn="辅助自慰" zh_tw="輔助自慰" jp="オナサポ" keyword=",自慰辅助,オナサポ,辅助自慰,輔助自慰," />
-      <a zh_cn="自慰" zh_tw="自慰" jp="自慰" keyword=",自慰,オナニー," />
-      <a zh_cn="洗浴" zh_tw="洗浴" jp="お風呂" keyword=",淋浴,お風呂,洗浴,洗澡," />
-      <a zh_cn="温泉" zh_tw="溫泉" jp="溫泉" keyword=",温泉,溫泉," />
-      <a zh_cn="寝取" zh_tw="寢取" jp="寝取られ" keyword=",寝取,寢取,寝取られ,寝取り·寝取られ·ntr,寝取り·寝取られ·ＮＴＲ," />
-      <a zh_cn="老太婆" zh_tw="老太婆" jp="お婆ちゃん" keyword=",お婆ちゃん,老太婆," />
-      <a zh_cn="老年男性" zh_tw="老年男性" jp="お爺ちゃん" keyword=",高龄男,お爺ちゃん,老年男性," />
-      <a zh_cn="接吻" zh_tw="接吻" jp="キス・接吻" keyword=",接吻,キス・接吻," />
-      <a zh_cn="介绍影片" zh_tw="介紹影片" jp="コミック雑誌" keyword=",コミック雑誌,介绍影片,介紹影片," />
-      <a zh_cn="心理惊悚" zh_tw="心理驚悚" jp="サイコ・スリラー" keyword=",サイコ・スリラー,心理惊悚,心理驚悚," />
-      <a zh_cn="打屁股" zh_tw="打屁股" jp="スパンキング" keyword=",虐打,スパンキング,打屁股," />
-      <a zh_cn="夫妻交换" zh_tw="夫妻交換" jp="スワッピング・夫婦交換" keyword=",夫妻交换,スワッピング・夫婦交換,夫妻交換," />
-      <a zh_cn="性感" zh_tw="性感" jp="セクシー" keyword=",性感的,性感的x,セクシー," />
-      <a zh_cn="性感内衣" zh_tw="性感内衣" jp="性感内衣" keyword=",性感内衣,內衣,内衣,ランジェリー," />
-      <a zh_cn="养尊处优" zh_tw="養尊處優" jp="セレブ" keyword=",セレブ,养尊处优,養尊處優," />
-      <a zh_cn="拉拉队" zh_tw="拉拉隊" jp="チアガール" keyword=",拉拉队长,チアガール,拉拉隊," />
-      <a zh_cn="假阳具" zh_tw="假陽具" jp="ディルド" keyword=",ディルド,假阳具,假陽具," />
-      <a zh_cn="约会" zh_tw="約會" jp="デート" keyword=",约会,デート,約會," />
-      <a zh_cn="巨根" zh_tw="巨根" jp="デカチン・巨根" keyword=",巨大陰莖,巨大阴茎,デカチン・巨根," />
-      <a zh_cn="不戴套" zh_tw="不戴套" jp="生ハメ" keyword=",不戴套,生ハメ," />
-      <a zh_cn="不穿内裤" zh_tw="不穿內褲" jp="ノーパン" keyword=",无内裤,ノーパン,不穿内裤,不穿內褲," />
-      <a zh_cn="不穿胸罩" zh_tw="不穿胸罩" jp="ノーブラ" keyword=",无胸罩,ノーブラ,不穿胸罩," />
-      <a zh_cn="后宫" zh_tw="後宮" jp="ハーレム" keyword=",ハーレム,后宫,後宮," />
-      <a zh_cn="后入" zh_tw="後入" jp="バック" keyword=",背后,バック,后入,後入," />
-      <a zh_cn="妓女" zh_tw="妓女" jp="ビッチ" keyword=",ビッチ,妓女,风俗女郎(性工作者)," />
-      <a zh_cn="感谢祭" zh_tw="感謝祭" jp="ファン感謝・訪問" keyword=",粉丝感谢,ファン感謝・訪問,感谢祭,感謝祭," />
-      <a zh_cn="大保健" zh_tw="大保健" jp="ヘルス・ソープ" keyword=",ヘルス・ソープ,大保健,按摩,マッサージ," />
-      <a zh_cn="按摩棒" zh_tw="按摩棒" jp="按摩棒" keyword=",女優按摩棒,女优按摩棒,按摩棒,电动按摩棒,電動按摩棒,電マ,バイブ," />
-      <a zh_cn="男同性恋" zh_tw="男同性戀" jp="ボーイ ズラブ" keyword=",ボーイズラブ,男同,男同性戀,男同性恋," />
-      <a zh_cn="酒店" zh_tw="酒店" jp="ホテル" keyword=",ホテル,酒店,飯店," />
-      <a zh_cn="酒店小姐" zh_tw="酒店小姐" jp="キャバ嬢" keyword=",キャバ嬢,酒店小姐," />
-      <a zh_cn="妈妈的朋友" zh_tw="媽媽的朋友" jp="ママ友" keyword=",ママ友,妈妈的朋友,媽媽的朋友," />
-      <a zh_cn="喜剧" zh_tw="喜劇" jp="ラブコメ" keyword=",喜剧,爱情喜剧,ラブコメ,喜劇,滑稽模仿,堵嘴·喜劇,整人・喜剧," />
-      <a zh_cn="恶搞" zh_tw="惡搞" jp="パロディ" keyword=",パロディ,惡搞,整人," />
-      <a zh_cn="白眼失神" zh_tw="白眼失神" jp="白目・失神" keyword=",翻白眼・失神,白目・失神,白眼失神," />
-      <a zh_cn="招待小姐" zh_tw="招待小姐" jp="受付嬢" keyword=",招待小姐,受付嬢,接待员," />
-      <a zh_cn="薄马赛克" zh_tw="薄馬賽克" jp="薄馬賽克" keyword=",薄馬賽克,薄马赛克," />
-      <a zh_cn="鼻钩" zh_tw="鼻鉤" jp="鼻フック" keyword=",鼻勾,鼻フック,鼻钩,鼻鉤," />
-      <a zh_cn="变性人" zh_tw="變性人" jp="變性者" keyword=",變性者,变性者,变性人,變性人," />
-      <a zh_cn="医院诊所" zh_tw="醫院診所" jp="病院・クリニック" keyword=",医院・诊所,病院・クリニック,医院诊所,醫院診所," />
-      <a zh_cn="社团经理" zh_tw="社團經理" jp="部活・マネージャー" keyword=",社团・经理,部活・マネージャー,社团经理,社團經理," />
-      <a zh_cn="下属·同事" zh_tw="下屬·同事" jp="部下・同僚" keyword=",下属・同事,部下・同僚,下属·同事,下屬·同事,同事,下屬,下属," />
-      <a zh_cn="残忍" zh_tw="殘忍" jp="殘忍" keyword=",殘忍,殘忍畫面,残忍画面,奇異的,奇异的," />
-      <a zh_cn="插入异物" zh_tw="插入異物" jp="插入異物" keyword=",插入異物,插入异物," />
-      <a zh_cn="潮吹" zh_tw="潮吹" jp="潮吹" keyword=",潮吹,潮吹き," />
-      <a zh_cn="男优潮吹" zh_tw="男優潮吹" jp="男の潮吹き" keyword=",男潮吹,男の潮吹き,男优潮吹,男優潮吹," />
-      <a zh_cn="巴士导游" zh_tw="巴士導遊" jp="車掌小姐" keyword=",車掌小姐,车掌小姐,巴士乘务员,巴士乘務員,巴士导游,巴士導遊,バスガイド," />
-      <a zh_cn="熟女" zh_tw="熟女" jp="熟女" keyword=",熟女,成熟的女人," />
-      <a zh_cn="出轨" zh_tw="出軌" jp="出軌" keyword=",出軌,出轨," />
-      <a zh_cn="白天出轨" zh_tw="白天出軌" jp="白天出轨" keyword=",白天出軌,白天出轨,通姦," />
-      <a zh_cn="处男" zh_tw="處男" jp="處男" keyword=",處男,处男," />
-      <a zh_cn="处女" zh_tw="處女" jp="處女" keyword=",處女,处女,処女,童貞," />
-      <a zh_cn="触手" zh_tw="觸手" jp="觸手" keyword=",觸手,触手," />
-      <a zh_cn="胁迫" zh_tw="胁迫" jp="胁迫" keyword=",魔鬼系,粗暴,胁迫," />
-      <a zh_cn="打手枪" zh_tw="打手槍" jp="打手槍" keyword=",手淫,打手枪,打手槍,手コキ," />
-      <a zh_cn="单体作品" zh_tw="單體作品" jp="單體作品" keyword=",单体作品,單體作品,単体作品,AV女优片," />
-      <a zh_cn="荡妇" zh_tw="蕩婦" jp="蕩婦" keyword=",蕩婦,荡妇," />
-      <a zh_cn="搭讪" zh_tw="搭訕" jp="搭訕" keyword=",倒追,女方搭讪,女方搭訕,搭讪,搭訕,ナンパ," />
-      <a zh_cn="女医师" zh_tw="女醫師" jp="女醫師" keyword=",女医师,女醫師,女医," />
-      <a zh_cn="主观视角" zh_tw="主觀視角" jp="主觀視角" keyword=",第一人稱攝影,第一人称摄影,主观视角,主觀視角,第一人称视点,主観," />
-      <a zh_cn="恶作剧" zh_tw="惡作劇" jp="惡作劇" keyword=",惡作劇,恶作剧," />
-      <a zh_cn="女服务生" zh_tw="女服務生" jp="ウェイトレス" keyword=",服務生,服务生,女服务生,女服務生,ウェイトレス," />
-      <a zh_cn="蒙面" zh_tw="蒙面" jp="覆面・マスク" keyword=",蒙面・面罩,蒙面・面具,覆面・マスク," />
-      <a zh_cn="肛交" zh_tw="肛交" jp="肛交" keyword=",肛交,アナル," />
-      <a zh_cn="肛内中出" zh_tw="肛內中出" jp="肛內中出" keyword=",肛内中出,肛內中出," />
-      <a zh_cn="个子高" zh_tw="個子高" jp="个子高" keyword=",高,个子高,個子高," />
-      <a zh_cn="高中生" zh_tw="高中生" jp="高中生" keyword=",高中女生,高中生," />
-      <a zh_cn="歌德萝莉" zh_tw="歌德蘿莉" jp="哥德蘿莉" keyword=",歌德萝莉,哥德蘿莉,歌德蘿莉," />
-      <a zh_cn="各种职业" zh_tw="各種職業" jp="各種職業" keyword=",各種職業,各种职业,多種職業,多种职业,職業色々," />
-      <a zh_cn="职业装" zh_tw="職業裝" jp="職業裝" keyword=",OL,洽公服装,职业装,職業裝,ビジネススーツ," />
-      <a zh_cn="女性向" zh_tw="女性向" jp="女性向け" keyword=",給女性觀眾,给女性观众,女性向,女性向け," />
-      <a zh_cn="寡妇" zh_tw="寡婦" jp="寡婦" keyword=",寡婦,寡妇," />
-      <a zh_cn="灌肠" zh_tw="灌腸" jp="灌腸" keyword=",灌腸,灌肠," />
-      <a zh_cn="进口" zh_tw="進口" jp="國外進口" keyword=",海外,進口,进口,國外進口,国外进口," />
-      <a zh_cn="流汗" zh_tw="流汗" jp="汗だく" keyword=",流汗,汗だく," />
-      <a zh_cn="共演" zh_tw="共演" jp="合作作品" keyword=",合作作品,共演," />
-      <a zh_cn="和服・丧服" zh_tw="和服・喪服" jp="和服・喪服" keyword=",和服・丧服,和服，喪服,和服、丧服,和服・喪服,和服·丧服,和服·喪服," />
-      <a zh_cn="和服・浴衣" zh_tw="和服・浴衣" jp="和服・浴衣" keyword=",浴衣,和服・浴衣,和服、浴衣," />
-      <a zh_cn="调教・奴隶" zh_tw="調教・奴隸" jp="調教・奴隸" keyword=",奴隸,奴隶,奴隷,調教・奴隷,調教,调教,调教・奴隶,调教·奴隶,調教·奴隸,調教・奴隸." />
-      <a zh_cn="黑帮成员" zh_tw="黑幫成員" jp="黑幫成員" keyword=",黑幫成員,黑帮成员," />
-      <a zh_cn="黑人" zh_tw="黑人" jp="黑人演員" keyword=",黑人,黑人演員,黑人演员,黒人男優," />
-      <a zh_cn="护士" zh_tw="護士" jp="ナース" keyword=",護士,护士,ナース," />
-      <a zh_cn="痴汉" zh_tw="痴漢" jp="痴漢" keyword=",痴漢,痴汉," />
-      <a zh_cn="痴女" zh_tw="癡女" jp="癡女" keyword=",花癡,痴女,癡女," />
-      <a zh_cn="新娘" zh_tw="新娘" jp="新娘" keyword=",花嫁,新娘,新娘，年輕妻子,新娘、年轻妻子,新娘、年輕妻子,新娘、少妇,新娘、少婦,花嫁・若妻," />
-      <a zh_cn="少妇" zh_tw="少婦" jp="少婦" keyword=",少妇,少婦," />
-      <a zh_cn="妄想" zh_tw="妄想" jp="妄想" keyword=",幻想,妄想,妄想族," />
-      <a zh_cn="及膝袜" zh_tw="及膝襪" jp="及膝襪" keyword=",及膝襪,及膝袜," />
-      <a zh_cn="纪录片" zh_tw="紀錄片" jp="纪录片" keyword=",紀錄片,纪录片," />
-      <a zh_cn="家庭教师" zh_tw="家庭教師" jp="家庭教師" keyword=",家教,家庭教师,家庭教師," />
-      <a zh_cn="娇小" zh_tw="嬌小" jp="嬌小的" keyword=",迷你系,迷你係列,娇小,嬌小,瘦小身型,嬌小的,迷你系‧小隻女,ミニ系・小柄," />
-      <a zh_cn="性教学" zh_tw="性教學" jp="性教學" keyword=",教學,教学,性教学,性教學," />
-      <a zh_cn="姐姐" zh_tw="姐姐" jp="姐姐" keyword=",姐姐,姐姐系,お姉さん," />
-      <a zh_cn="姐·妹" zh_tw="姐·妹" jp="姐·妹" keyword=",妹妹,姐妹,姐·妹,姊妹," />
-      <a zh_cn="穿衣幹砲" zh_tw="穿衣幹砲" jp="着エロ" keyword=",穿衣幹砲,着エロ," />
-      <a zh_cn="紧缚" zh_tw="緊縛" jp="緊縛" keyword=",緊縛,紧缚,縛り・緊縛,紧缚," />
-      <a zh_cn="紧身衣" zh_tw="緊身衣" jp="緊身衣" keyword=",緊身衣,紧身衣,紧缚皮衣,緊縛皮衣,紧身衣激凸,緊身衣激凸,ボディコン," />
-      <a zh_cn="经典老片" zh_tw="經典老片" jp="經典" keyword=",經典,经典,经典老片,經典老片," />
-      <a zh_cn="监禁" zh_tw="監禁" jp="監禁" keyword=",監禁,监禁," />
-      <a zh_cn="强奸" zh_tw="強姦" jp="強姦" keyword=",強姦,强奸,強暴,强暴,レイプ," />
-      <a zh_cn="轮奸" zh_tw="輪姦" jp="輪姦" keyword=",輪姦,轮奸,轮姦," />
-      <a zh_cn="私处近拍" zh_tw="私處近拍" jp="私處近拍" keyword=",私处近拍,私處近拍,局部特寫,局部特写,局部アップ," />
-      <a zh_cn="巨尻" zh_tw="巨尻" jp="巨尻" keyword=",大屁股,巨大屁股,巨尻," />
-      <a zh_cn="巨乳" zh_tw="巨乳" jp="巨乳" keyword=",巨乳,巨乳爆乳,爱巨乳,愛巨乳,巨乳フェチ," />
-      <a zh_cn="窈窕" zh_tw="窈窕" jp="スレンダー" keyword=",窈窕,スレンダー," />
-      <a zh_cn="美腿" zh_tw="美腿" jp="美腿" keyword=",美腿,美脚,爱美腿,愛美腿,脚フェチ," />
-      <a zh_cn="修长" zh_tw="修長" jp="長身" keyword=",修長,長身," />
-      <a zh_cn="爱美臀" zh_tw="愛美臀" jp="尻フェチ" keyword=",爱美臀,愛美臀,尻フェチ," />
-      <a zh_cn="奇幻" zh_tw="奇幻" jp="科幻" keyword=",科幻,奇幻," />
-      <a zh_cn="空姐" zh_tw="空姐" jp="スチュワーデス" keyword=",空中小姐,空姐,スチュワーデス," />
-      <a zh_cn="口交" zh_tw="口交" jp="フェラ" keyword=",口交,フェラ,双重口交,雙重口交,Wフェラ," />
-      <a zh_cn="强迫口交" zh_tw="強迫口交" jp="強迫口交" keyword=",强迫口交,強迫口交,イラマチオ," />
-      <a zh_cn="偷拍" zh_tw="偷拍" jp="盗撮" keyword=",偷拍,盗撮," />
-      <a zh_cn="蜡烛" zh_tw="蠟燭" jp="蝋燭" keyword=",蜡烛,蝋燭,蠟燭," />
-      <a zh_cn="滥交" zh_tw="濫交" jp="濫交" keyword=",濫交,滥交,乱交,亂交," />
-      <a zh_cn="酒醉" zh_tw="酒醉" jp="爛醉如泥的" keyword=",爛醉如泥的,烂醉如泥的,酒醉," />
-      <a zh_cn="立即插入" zh_tw="立即插入" jp="立即插入" keyword=",立即口交,即兴性交,立即插入,马上幹,馬上幹,即ハメ," />
-      <a zh_cn="连裤袜" zh_tw="連褲襪" jp="連褲襪" keyword=",連褲襪,连裤袜," />
-      <a zh_cn="连发" zh_tw="連發" jp="連発" keyword=",连发,連發,連発," />
-      <a zh_cn="恋爱" zh_tw="戀愛" jp="戀愛" keyword=",戀愛,恋爱,恋愛," />
-      <a zh_cn="恋乳癖" zh_tw="戀乳癖" jp="戀乳癖" keyword=",戀乳癖,恋乳癖," />
-      <a zh_cn="恋腿癖" zh_tw="戀腿癖" jp="戀腿癖" keyword=",戀腿癖,恋腿癖," />
-      <a zh_cn="猎艳" zh_tw="獵艷" jp="獵豔" keyword=",獵豔,猎艳,獵艷," />
-      <a zh_cn="乱伦" zh_tw="亂倫" jp="亂倫" keyword=",亂倫,乱伦," />
-      <a zh_cn="萝莉" zh_tw="蘿莉" jp="蘿莉塔" keyword=",蘿莉塔,萝莉塔,ロリ," />
-      <a zh_cn="裸体围裙" zh_tw="裸體圍裙" jp="裸體圍裙" keyword=",裸體圍裙,裸体围裙,真空围裙,真空圍裙,裸エプロン," />
-      <a zh_cn="骂倒" zh_tw="罵倒" jp="罵倒" keyword=",罵倒,骂倒," />
-      <a zh_cn="蛮横娇羞" zh_tw="蠻橫嬌羞" jp="蠻橫嬌羞" keyword=",蠻橫嬌羞,蛮横娇羞," />
-      <a zh_cn="猫耳" zh_tw="貓耳" jp="貓耳女" keyword=",貓耳女,猫耳女," />
-      <a zh_cn="美容院" zh_tw="美容院" jp="美容院" keyword=",美容院,エステ," />
-      <a zh_cn="美少女" zh_tw="美少女" jp="美少女" keyword=",美少女,美少女電影,美少女电影," />
-      <a zh_cn="迷你裙" zh_tw="迷你裙" jp="迷你裙" keyword=",迷你裙,ミニスカ," />
-      <a zh_cn="秘书" zh_tw="秘書" jp="秘書" keyword=",秘書,秘书," />
-      <a zh_cn="面试" zh_tw="面試" jp="面接" keyword=",面试,面接,面試," />
-      <a zh_cn="苗条" zh_tw="苗條" jp="苗條" keyword=",苗條,苗条," />
-      <a zh_cn="明星脸" zh_tw="明星臉" jp="明星臉" keyword=",明星臉,明星脸," />
-      <a zh_cn="模特" zh_tw="模特" jp="模特兒" keyword=",模特兒,模特儿,モデル," />
-      <a zh_cn="母亲" zh_tw="母親" jp="母親" keyword=",母親,母亲,妈妈系,媽媽系,お母さん," />
-      <a zh_cn="义母" zh_tw="義母" jp="母親" keyword=",义母,義母," />
-      <a zh_cn="女强男" zh_tw="女强男" jp="逆レイプ" keyword=",逆レイプ,女强男," />
-      <a zh_cn="养女" zh_tw="養女" jp="娘・養女" keyword=",养女,娘・養女," />
-      <a zh_cn="女大学生" zh_tw="女大學生" jp="女子大生" keyword=",女大學生,女大学生,女子大生," />
-      <a zh_cn="女搜查官" zh_tw="女搜查官" jp="女檢察官" keyword=",女檢察官,女检察官,女搜查官," />
-      <a zh_cn="女教师" zh_tw="女教師" jp="女教師" keyword=",女教師,女教师," />
-      <a zh_cn="女忍者" zh_tw="女忍者" jp="女忍者" keyword=",女忍者,くノ一," />
-      <a zh_cn="骑乘位" zh_tw="騎乘位" jp="騎乗位" keyword=",女上位,骑乘,騎乘,骑乘位,騎乘位,騎乗位," />
-      <a zh_cn="辣妹" zh_tw="辣妹" jp="辣妹" keyword=",女生,辣妹,ギャル," />
-      <a zh_cn="女同性恋" zh_tw="女同性戀" jp="女同性戀" keyword=",女同性戀,女同性恋,女同志,レズ," />
-      <a zh_cn="女王" zh_tw="女王" jp="女王様" keyword=",女王,女王様," />
-      <a zh_cn="女医生" zh_tw="女醫生" jp="女醫生" keyword=",女醫生,女医生," />
-      <a zh_cn="女仆" zh_tw="女僕" jp="メイド" keyword=",女傭,女佣,女仆,女僕,メイド," />
-      <a zh_cn="女优最佳合集" zh_tw="女優最佳合集" jp="女優ベスト・総集編" keyword=",女優ベスト・総集編,女优最佳合集,女優最佳合集," />
-      <a zh_cn="女战士" zh_tw="女戰士" jp="超級女英雄" keyword=",行動,行动,超級女英雄,女战士,女戰士," />
-      <a zh_cn="女主播" zh_tw="女主播" jp="女子アナ" keyword=",女主播,女子アナ," />
-      <a zh_cn="女主人" zh_tw="女主人" jp="老闆娘" keyword=",女主人,老闆娘，女主人,老板娘、女主人,女主人、女老板,女将・女主人," />
-      <a zh_cn="女装人妖" zh_tw="女裝人妖" jp="女裝人妖" keyword=",女裝人妖,女装人妖," />
-      <a zh_cn="呕吐" zh_tw="嘔吐" jp="嘔吐" keyword=",呕吐,嘔吐," />
-      <a zh_cn="粪便" zh_tw="糞便" jp="糞便" keyword=",排便,粪便,糞便,食糞,食粪," />
-      <a zh_cn="坦克" zh_tw="坦克" jp="胖女人" keyword=",胖女人,坦克," />
-      <a zh_cn="泡泡袜" zh_tw="泡泡襪" jp="泡泡襪" keyword=",泡泡袜,泡泡襪," />
-      <a zh_cn="美臀" zh_tw="美臀" jp="屁股" keyword=",美臀,屁股," />
-      <a zh_cn="平胸" zh_tw="平胸" jp="貧乳・微乳" keyword=",平胸,貧乳・微乳," />
-      <a zh_cn="丈母娘" zh_tw="丈母娘" jp="婆婆" keyword=",婆婆,后母,丈母娘," />
-      <a zh_cn="恋物癖" zh_tw="戀物癖" jp="戀物癖" keyword="戀物癖,恋物癖,其他戀物癖,其他恋物癖," />
-      <a zh_cn="其他癖好" zh_tw="其他癖好" jp="その他フェチ" keyword="其他癖好,その他フェチ," />
-      <a zh_cn="企画" zh_tw="企畫" jp="企畫" keyword=",企畫,企画," />
-      <a zh_cn="车震" zh_tw="車震" jp="汽車性愛" keyword=",汽車性愛,汽车性爱,车震,車震,车床族,車床族,カーセックス," />
-      <a zh_cn="大小姐" zh_tw="大小姐" jp="千金小姐" keyword=",大小姐,千金小姐," />
-      <a zh_cn="情侣" zh_tw="情侶" jp="情侶" keyword=",情侶,情侣,伴侶,伴侣,カップル," />
-      <a zh_cn="晒黑" zh_tw="曬黑" jp="日焼け" keyword=",曬黑,晒黑,日焼け," />
-      <a zh_cn="美乳" zh_tw="美乳" jp="美乳" keyword=",乳房,美乳," />
-      <a zh_cn="乳交" zh_tw="乳交" jp="乳交" keyword=",乳交,パイズリ," />
-      <a zh_cn="乳液" zh_tw="乳液" jp="乳液" keyword=",乳液,ローション・オイル,ローション·オイル," />
-      <a zh_cn="软体" zh_tw="軟體" jp="軟体" keyword=",软体,軟体,軟體," />
-      <a zh_cn="搔痒" zh_tw="搔癢" jp="瘙癢" keyword=",搔痒,瘙癢,搔癢," />
-      <a zh_cn="设计环节" zh_tw="設計環節" jp="設置項目" keyword=",設置項目,设计环节,設計環節," />
-      <a zh_cn="丰乳肥臀" zh_tw="豐乳肥臀" jp="身體意識" keyword=",身體意識,身体意识,丰乳肥臀,豐乳肥臀," />
-      <a zh_cn="时间停止" zh_tw="時間停止" jp="時間停止" keyword=",时间停止,時間停止," />
-      <a zh_cn="插入手指" zh_tw="插入手指" jp="手指插入" keyword=",手指插入,插入手指," />
-      <a zh_cn="叔母" zh_tw="叔母" jp="叔母さん" keyword=",叔母,叔母さん," />
-      <a zh_cn="数位马赛克" zh_tw="數位馬賽克" jp="數位馬賽克" keyword=",數位馬賽克,数位马赛克," />
-      <a zh_cn="双性人" zh_tw="雙性人" jp="雙性人" keyword=",雙性人,双性人," />
-      <a zh_cn="韵律服" zh_tw="韻律服" jp="レオタード" keyword=",韵律服,韻律服,レオタード," />
-      <a zh_cn="水手服" zh_tw="水手服" jp="セーラー服" keyword=",水手服,セーラー服," />
-      <a zh_cn="丝袜" zh_tw="絲襪" jp="絲襪" keyword=",丝袜,絲襪,パンスト," />
-      <a zh_cn="特摄" zh_tw="特攝" jp="特攝" keyword=",特效,特摄,特攝," />
-      <a zh_cn="经历告白" zh_tw="經歷告白" jp="體驗懺悔" keyword=",體驗懺悔,经历告白,經歷告白," />
-      <a zh_cn="体操服" zh_tw="體操服" jp="體育服" keyword=",体操服,體育服,體操服," />
-      <a zh_cn="舔阴" zh_tw="舔陰" jp="舔陰" keyword=",舔陰,舔阴,舔鲍,クンニ," />
-      <a zh_cn="跳蛋" zh_tw="跳蛋" jp="ローター" keyword=",跳蛋,ローター," />
-      <a zh_cn="青梅竹马" zh_tw="青梅竹馬" jp="童年朋友" keyword=",童年朋友,青梅竹马,青梅竹馬," />
-      <a zh_cn="偷窥" zh_tw="偷窺" jp="偷窥" keyword=",偷窺,偷窥," />
-      <a zh_cn="赛车女郎" zh_tw="賽車女郎" jp="レースクィーン" keyword=",賽車女郎,赛车女郎,レースクィーン," />
-      <a zh_cn="兔女郎" zh_tw="兔女郎" jp="兔女郎" keyword=",兔女郎,バニーガール," />
-      <a zh_cn="吞精" zh_tw="吞精" jp="吞精" keyword=",吞精,ごっくん," />
-      <a zh_cn="成人动画" zh_tw="成人動畫" jp="アニメ" keyword=",成人动画,成人動畫,アニメ," />
-      <a zh_cn="成人娃娃" zh_tw="成人娃娃" jp="娃娃" keyword=",娃娃,成人娃娃," />
-      <a zh_cn="玩物" zh_tw="玩物" jp="玩具" keyword=",玩具,玩物," />
-      <a zh_cn="适合手机垂直播放" zh_tw="適合手機垂直播放" jp="為智能手機推薦垂直視頻" keyword=",スマホ専用縦動画,為智能手機推薦垂直視頻,适合手机垂直播放,適合手機垂直播放," />
-      <a zh_cn="猥亵穿着" zh_tw="猥褻穿着" jp="猥褻穿著" keyword=",猥褻穿著,猥亵穿着,猥褻穿着," />
-      <a zh_cn="无码流出" zh_tw="無碼流出" jp="无码流出" keyword=",無碼流出,无码流出," />
-      <a zh_cn="无码破解" zh_tw="無碼破解" jp="無碼破解" keyword=",無碼破解,无码破解," />
-      <a zh_cn="无毛" zh_tw="無毛" jp="無毛" keyword=",無毛,无毛,剃毛,白虎,パイパン," />
-      <a zh_cn="剧情" zh_tw="劇情" jp="戲劇" keyword=",戲劇,戏剧,剧情,劇情,戲劇x,戏剧、连续剧,戲劇、連續劇,ドラマ," />
-      <a zh_cn="性转换·男变女" zh_tw="性轉換·男變女" jp="性別轉型·女性化" keyword=",性转换・女体化,性別轉型·女性化,性转换·男变女,性轉換·男變女," />
-      <a zh_cn="性骚扰" zh_tw="性騷擾" jp="性騷擾" keyword=",性騷擾,性骚扰," />
-      <a zh_cn="故意露胸" zh_tw="故意露胸" jp="胸チラ" keyword=",胸チラ,故意露胸," />
-      <a zh_cn="羞耻" zh_tw="羞恥" jp="羞恥" keyword=",羞恥,羞耻," />
-      <a zh_cn="学生" zh_tw="學生" jp="學生" keyword=",學生,其他學生,其他学生,學生（其他）,学生," />
-      <a zh_cn="学生妹" zh_tw="學生妹" jp="學生妹" keyword=",学生妹,學生妹,女子校生," />
-      <a zh_cn="学生服" zh_tw="學生服" jp="學生服" keyword=",学生服,學生服," />
-      <a zh_cn="学生泳装" zh_tw="學生泳裝" jp="學校泳裝" keyword=",學校泳裝,学校泳装,学生泳装,學生泳裝,校园泳装,校園泳裝,競泳・スクール水着," />
-      <a zh_cn="泳装" zh_tw="泳裝" jp="水着" keyword=",泳裝,泳装,水着," />
-      <a zh_cn="校园" zh_tw="校園" jp="學校作品" keyword=",學校作品,学校作品,校园,校園,校园物语,校園物語,学園もの," />
-      <a zh_cn="肛检" zh_tw="肛檢" jp="鴨嘴" keyword=",鴨嘴,鸭嘴,肛检,肛檢," />
-      <a zh_cn="骑脸" zh_tw="騎臉" jp="顏面騎乘" keyword=",騎乗位,颜面骑乘,顏面騎乘,骑脸,騎臉," />
-      <a zh_cn="颜射" zh_tw="顏射" jp="顔射" keyword=",顏射,颜射,顏射x,顔射," />
-      <a zh_cn="眼镜" zh_tw="眼鏡" jp="眼鏡" keyword=",眼鏡,眼镜,メガネ," />
-      <a zh_cn="药物" zh_tw="藥物" jp="藥物" keyword=",藥物,药物,药物、迷姦,藥物、迷姦,ドラッグ," />
-      <a zh_cn="野外露出" zh_tw="野外露出" jp="野外・露出" keyword=",野外・露出,野外露出,野外," />
-      <a zh_cn="业余" zh_tw="業餘" jp="業餘" keyword=",業餘,业余,素人," />
-      <a zh_cn="人妻" zh_tw="人妻" jp="已婚婦女" keyword=",已婚婦女,已婚妇女,人妻," />
-      <a zh_cn="近亲相姦" zh_tw="近親相姦" jp="近親相姦" keyword=",近亲相姦,近親相姦," />
-      <a zh_cn="自拍" zh_tw="自拍" jp="ハメ撮り" keyword=",自拍,ハメ撮り,個人撮影,个人撮影," />
-      <a zh_cn="淫语" zh_tw="淫語" jp="淫語" keyword=",淫語,淫语," />
-      <a zh_cn="酒会" zh_tw="酒會" jp="飲み会・合コン" keyword=",饮酒派对,飲み会・合コン,酒会,酒會," />
-      <a zh_cn="饮尿" zh_tw="飲尿" jp="飲尿" keyword=",飲尿,饮尿," />
-      <a zh_cn="游戏改" zh_tw="遊戲改" jp="遊戲的真人版" keyword=",遊戲的真人版,游戏改,遊戲改," />
-      <a zh_cn="漫改" zh_tw="漫改" jp="原作コラボ" keyword=",原作改編,原作改编,原作コラボ,漫改," />
-      <a zh_cn="受孕" zh_tw="受孕" jp="孕ませ" keyword=",受孕,孕ませ," />
-      <a zh_cn="孕妇" zh_tw="孕婦" jp="孕婦" keyword=",孕婦,孕妇," />
-      <a zh_cn="早泄" zh_tw="早泄" jp="早漏" keyword=",早洩,早漏,早泄," />
-      <a zh_cn="Show Girl" zh_tw="Show Girl" jp="展場女孩" keyword=",展場女孩,展场女孩,Show Girl," />
-      <a zh_cn="中出" zh_tw="中出" jp="中出" keyword=",中出,中出し," />
-      <a zh_cn="子宫颈" zh_tw="子宮頸" jp="子宮頸" keyword=",子宮頸,子宫颈," />
-      <a zh_cn="足交" zh_tw="足交" jp="足交" keyword=",足交,足コキ," />
-      <a zh_cn="4小时+" zh_tw="4小時+" jp="4小時以上作品" keyword=",4小時以上作品,4小时以上作品,4小时+,4小時+," />
-      <a zh_cn="学生" zh_tw="學生" jp="學生" keyword=",C学生,學生," />
-      <a zh_cn="暗黑系" zh_tw="暗黑系" jp="暗黑系" keyword=",暗黑系,黑暗系統," />
-      <a zh_cn="成人电影" zh_tw="成人電影" jp="成人電影" keyword=",成人電影,成人电影," />
-      <a zh_cn="成人动漫" zh_tw="成人動漫" jp="成人動漫" keyword=",成人动漫,成人動漫," />
-      <a zh_cn="导尿" zh_tw="導尿" jp="導尿" keyword=",導尿,导尿," />
-      <a zh_cn="法国" zh_tw="法國" jp="法國" keyword=",法国,法國," />
-      <a zh_cn="飞特族" zh_tw="飛特族" jp="飛特族" keyword=",飛特族,飞特族," />
-      <a zh_cn="韩国" zh_tw="韓國" jp="韓國" keyword=",韓國,韩国," />
-      <a zh_cn="户外" zh_tw="戶外" jp="戶外" keyword=",戶外,户外," />
-      <a zh_cn="角色对换" zh_tw="角色對換" jp="角色對換" keyword=",角色对换,角色對換," />
-      <a zh_cn="精选综合" zh_tw="精選綜合" jp="合集" keyword=",精選，綜合,精选、综合,合集,精选综合,精選綜合," />
-      <a zh_cn="捆绑" zh_tw="捆綁" jp="捆綁" keyword=",捆綁,捆绑,折磨," />
-      <a zh_cn="礼仪小姐" zh_tw="禮儀小姐" jp="禮儀小姐" keyword=",禮儀小姐,礼仪小姐," />
-      <a zh_cn="历史剧" zh_tw="歷史劇" jp="歷史劇" keyword=",歷史劇,历史剧," />
-      <a zh_cn="母狗" zh_tw="母狗" jp="母狗" keyword=",母犬,母狗," />
-      <a zh_cn="男优介绍" zh_tw="男優介紹" jp="男優介紹" keyword=",男性,男优介绍,男優介紹," />
-      <a zh_cn="女儿" zh_tw="女兒" jp="女兒" keyword=",女兒,女儿," />
-      <a zh_cn="窥乳" zh_tw="窺乳" jp="窺乳" keyword=",乳房偷窺,窥乳,窺乳," />
-      <a zh_cn="羞辱" zh_tw="羞辱" jp="辱め" keyword=",凌辱,羞辱,辱め,辱骂,辱罵," />
-      <a zh_cn="脱衣" zh_tw="脫衣" jp="脫衣" keyword=",脫衣,脱衣," />
-      <a zh_cn="写真偶像" zh_tw="寫真偶像" jp="寫真偶像" keyword=",寫真偶像,写真偶像," />
-      <a zh_cn="偶像艺人" zh_tw="偶像藝人" jp="アイドル芸能人" keyword=",藝人,艺人,偶像,偶像藝人,偶像艺人,偶像‧藝人,偶像‧艺人,アイドル・芸能人," />
-      <a zh_cn="淫乱真实" zh_tw="淫亂真實" jp="淫亂真實" keyword=",淫亂，真實,淫乱、真实,淫乱真实,淫亂真實,淫乱・ハード系," />
-      <a zh_cn="瑜伽·健身" zh_tw="瑜伽·健身" jp="瑜伽·健身" keyword=",瑜伽,瑜伽·健身,ヨガ,講師,讲师" />
-      <a zh_cn="运动短裤" zh_tw="運動短褲" jp="運動短褲" keyword=",運動短褲,运动短裤," />
-      <a zh_cn="JK制服" zh_tw="JK制服" jp="JK制服" keyword=",制服外套,JK制服,校服," />
-      <a zh_cn="重制版" zh_tw="重製版" jp="複刻版" keyword=",重印版,複刻版,重制版,重製版," />
-      <a zh_cn="综合短篇" zh_tw="綜合短篇" jp="綜合短篇" keyword=",綜合短篇,综合短篇," />
-      <a zh_cn="被外国人干" zh_tw="被外國人乾" jp="被外國人乾" keyword=",被外國人幹,被外国人干,被外國人乾," />
-      <a zh_cn="二穴同入" zh_tw="二穴同入" jp="二穴同入" keyword=",二穴同時挿入,二穴同入," />
-      <a zh_cn="美脚" zh_tw="美腳" jp="美腳" keyword=",美腳,美脚," />
-      <a zh_cn="过膝袜" zh_tw="過膝襪" jp="過膝襪" keyword=",絲襪、過膝襪,过膝袜," />
-      <a zh_cn="欲女" zh_tw="欲女" jp="エマニエル" keyword=",エマニエル,欲女," />
-      <a zh_cn="高筒靴" zh_tw="高筒靴" jp="高筒靴" keyword=",靴子,高筒靴," />
-      <a zh_cn="双飞" zh_tw="雙飛" jp="雙飛" keyword=",兩女一男,双飞,雙飛," />
-      <a zh_cn="两女两男" zh_tw="兩女兩男" jp="兩女兩男" keyword=",兩男兩女,两女两男,兩女兩男," />
-      <a zh_cn="两男一女" zh_tw="兩男一女" jp="兩男一女" keyword=",兩男一女,两男一女," />
-      <a zh_cn="3P" zh_tw="3P" jp="3P" keyword=",3P,3p,３P,３p," />
-      <a zh_cn="S1 NO.1 STYLE" zh_tw="S1 NO.1 STYLE" jp="S1 NO.1 STYLE" keyword=",S1 Style,エスワン,エスワン ナンバーワンスタイル,エスワンナンバーワンスタイル,S1 NO.1 STYLE,S1NO.1STYLE," />
-      <a zh_cn="加勒比" zh_tw="加勒比" jp="加勒比" keyword=",加勒比,カリビアンコム," />
-      <a zh_cn="东京热" zh_tw="東京熱" jp="TOKYO-HOT" keyword=",东京热,東京熱,東熱,TOKYO-HOT," />
-      <a zh_cn="SOD" zh_tw="SOD" jp="SOD" keyword=",SOD,SODクリエイト," />
-      <a zh_cn="PRESTIGE" zh_tw="PRESTIGE" jp="PRESTIGE" keyword=",PRESTIGE,プレステージ," />
-      <a zh_cn="MOODYZ" zh_tw="MOODYZ" jp="MOODYZ" keyword=",MOODYZ,ムーディーズ," />
-      <a zh_cn="S级素人" zh_tw="S級素人" jp="S級素人" keyword=",S級素人,アイデアポケット," />
-      <a zh_cn="玛丹娜" zh_tw="瑪丹娜" jp="Madonna" keyword=",玛丹娜,瑪丹娜,マドンナ,Madonna," />
-      <a zh_cn="MAXING" zh_tw="MAXING" jp="MAXING" keyword=",MAXING,マキシング," />
-      <a zh_cn="JAPANKET" zh_tw="ALICE JAPAN" jp="ALICE JAPAN" keyword=",ALICE JAPAN,アリスJAPAN," />
-      <a zh_cn="Natural High" zh_tw="Natural High" jp="Natural High" keyword=",Natural High,ナチュラルハイ," />
-      <a zh_cn="K.M.P" zh_tw="K.M.P" jp="K.M.P" keyword=",K.M.P,ケイ・エム・プロデュース," />
-      <a zh_cn="熘池五郎" zh_tw="溜池五郎" jp="溜池ゴロー" keyword=",熘池五郎,溜池五郎,溜池ゴロー," />
-      <a zh_cn="PREMIUM" zh_tw="PREMIUM" jp="PREMIUM" keyword=",PREMIUM,プレミアム," />
-      <a zh_cn="WANZ" zh_tw="WANZ" jp="WANZ" keyword=",WANZ,ワンズファクトリー," />
-      <a zh_cn="MAX-A" zh_tw="MAX-A" jp="MAX-A" keyword=",MAX-A,マックスエー," />
+    <a zh_cn="16小时+" zh_tw="16小時+" jp="16時間以上作品"
+       keyword=",16小時以上作品,16小时以上作品,16時間以上作品,16小时+,16小時+,"/>
+    <a zh_cn="3D" zh_tw="3D" jp="3D" keyword=",3D,"/>
+    <a zh_cn="3D卡通" zh_tw="3D卡通" jp="3Dエロアニメ" keyword=",3D卡通,3Dエロアニメ,"/>
+    <a zh_cn="4K" zh_tw="4K" jp="4K" keyword=",4K,"/>
+    <a zh_cn="DMM独家" zh_tw="DMM獨家" jp="DMM獨家" keyword=",DMM獨家,DMM独家,DMM專屬,DMM专属,"/>
+    <a zh_cn="M女" zh_tw="M女" jp="M女" keyword=",M女,"/>
+    <a zh_cn="SM" zh_tw="SM" jp="SM" keyword=",SM,"/>
+    <a zh_cn="轻虐" zh_tw="輕虐" jp="微SM" keyword=",微SM,轻虐,輕虐,"/>
+    <a zh_cn="VR" zh_tw="VR" jp="VR" keyword=",VR,VR専用,高品质VR,ハイクオリティVR,"/>
+    <a zh_cn="8K VR" zh_tw="8K VR" jp="8K VR" keyword=",8K VR,"/>
+    <a zh_cn="武术格斗" zh_tw="武術格鬥" jp="アクション"
+       keyword=",戰鬥行動,战斗行动,アクション,武术格斗,武術格鬥,アクション・格闘,"/>
+    <a zh_cn="格斗家" zh_tw="格鬥家" jp="格闘家" keyword=",格鬥家,格闘家,格斗家,"/>
+    <a zh_cn="教练" zh_tw="教練" jp="インストラクター" keyword=",教练,教練,インストラクター,"/>
+    <a zh_cn="绝顶高潮" zh_tw="絕頂高潮" jp="アクメ・オーガズム" keyword=",极致·性高潮,アクメ・オーガズム,绝顶高潮,絕頂高潮,"/>
+    <a zh_cn="运动" zh_tw="運動" jp="アスリート" keyword=",运动员,アスリート,運動,运动,スポーツ,"/>
+    <a zh_cn="动画角色" zh_tw="動畫角色" jp="動畫人物" keyword=",动漫,動画,動畫人物,动画人物,动画角色,動畫角色,アニメ,"/>
+    <a zh_cn="角色扮演" zh_tw="角色扮演" jp="角色扮演" keyword=",角色扮演者,角色扮演,コスプレ,COSPLAY,COSPLAY服飾,COSPLAY服饰,"/>
+    <a zh_cn="萝莉Cos" zh_tw="蘿莉Cos" jp="蘿莉Cos" keyword=",蘿莉角色扮演,萝莉角色扮演,萝莉Cos,蘿莉Cos,"/>
+    <a zh_cn="纯欲" zh_tw="純欲" jp="エロス" keyword=",エロス,纯欲,純欲,"/>
+    <a zh_cn="御宅族" zh_tw="御宅族" jp="オタク" keyword=",御宅族,オタク,"/>
+    <a zh_cn="辅助自慰" zh_tw="輔助自慰" jp="オナサポ" keyword=",自慰辅助,オナサポ,辅助自慰,輔助自慰,"/>
+    <a zh_cn="自慰" zh_tw="自慰" jp="自慰" keyword=",自慰,オナニー,"/>
+    <a zh_cn="洗浴" zh_tw="洗浴" jp="お風呂" keyword=",淋浴,お風呂,洗浴,洗澡,"/>
+    <a zh_cn="温泉" zh_tw="溫泉" jp="溫泉" keyword=",温泉,溫泉,"/>
+    <a zh_cn="寝取" zh_tw="寢取" jp="寝取られ" keyword=",寝取,寢取,寝取られ,寝取り·寝取られ·ntr,寝取り·寝取られ·ＮＴＲ,寝取り・寝取られ・NTR,"/>
+    <a zh_cn="老太婆" zh_tw="老太婆" jp="お婆ちゃん" keyword=",お婆ちゃん,老太婆,"/>
+    <a zh_cn="老年男性" zh_tw="老年男性" jp="お爺ちゃん" keyword=",高龄男,お爺ちゃん,老年男性,"/>
+    <a zh_cn="接吻" zh_tw="接吻" jp="キス・接吻" keyword=",接吻,キス・接吻,"/>
+    <a zh_cn="女同接吻" zh_tw="女同接吻" jp="女同接吻" keyword=",女同接吻,"/>
+    <a zh_cn="介绍影片" zh_tw="介紹影片" jp="コミック雑誌" keyword=",コミック雑誌,介绍影片,介紹影片,"/>
+    <a zh_cn="心理惊悚" zh_tw="心理驚悚" jp="サイコ・スリラー" keyword=",サイコ・スリラー,心理惊悚,心理驚悚,"/>
+    <a zh_cn="打屁股" zh_tw="打屁股" jp="スパンキング" keyword=",虐打,スパンキング,打屁股,"/>
+    <a zh_cn="夫妻交换" zh_tw="夫妻交換" jp="スワッピング・夫婦交換" keyword=",夫妻交换,スワッピング・夫婦交換,夫妻交換,"/>
+    <a zh_cn="性感" zh_tw="性感" jp="セクシー" keyword=",性感的,性感的x,セクシー,"/>
+    <a zh_cn="性感内衣" zh_tw="性感内衣" jp="性感内衣" keyword=",性感内衣,內衣,内衣,ランジェリー,"/>
+    <a zh_cn="养尊处优" zh_tw="養尊處優" jp="セレブ" keyword=",セレブ,养尊处优,養尊處優,"/>
+    <a zh_cn="拉拉队" zh_tw="拉拉隊" jp="チアガール" keyword=",拉拉队长,チアガール,拉拉隊,"/>
+    <a zh_cn="假阳具" zh_tw="假陽具" jp="ディルド" keyword=",ディルド,假阳具,假陽具,"/>
+    <a zh_cn="约会" zh_tw="約會" jp="デート" keyword=",约会,デート,約會,"/>
+    <a zh_cn="巨根" zh_tw="巨根" jp="デカチン・巨根" keyword=",巨大陰莖,巨大阴茎,デカチン・巨根,"/>
+    <a zh_cn="不戴套" zh_tw="不戴套" jp="生ハメ" keyword=",不戴套,生ハメ,"/>
+    <a zh_cn="看内裤" zh_tw="看内裤" jp="パンチラ" keyword=",看内裤,パンチラ,"/>
+    <a zh_cn="不穿内裤" zh_tw="不穿內褲" jp="ノーパン" keyword=",无内裤,ノーパン,不穿内裤,不穿內褲,"/>
+    <a zh_cn="不穿胸罩" zh_tw="不穿胸罩" jp="ノーブラ" keyword=",无胸罩,ノーブラ,不穿胸罩,"/>
+    <a zh_cn="不伦" zh_tw="不倫" jp="不倫" keyword=",不倫,"/>
+    <a zh_cn="后宫" zh_tw="後宮" jp="ハーレム" keyword=",ハーレム,后宫,後宮,"/>
+    <a zh_cn="后入" zh_tw="後入" jp="バック" keyword=",背后,バック,后入,後入,"/>
+    <a zh_cn="妓女" zh_tw="妓女" jp="ビッチ" keyword=",ビッチ,妓女,风俗女郎(性工作者),"/>
+    <a zh_cn="记录片" zh_tw="記錄片" jp="ドキュメンタリー" keyword=",记录片,記錄片,ドキュメンタリー,"/>
+    <a zh_cn="感谢祭" zh_tw="感謝祭" jp="ファン感謝・訪問" keyword=",粉丝感谢,ファン感謝・訪問,感谢祭,感謝祭,"/>
+    <a zh_cn="大保健" zh_tw="大保健" jp="ヘルス・ソープ" keyword=",ヘルス・ソープ,大保健,按摩,足疗,マッサージ・リフレ,マッサージ,"/>
+    <a zh_cn="按摩棒" zh_tw="按摩棒" jp="按摩棒"
+       keyword=",女優按摩棒,女优按摩棒,按摩棒,电动按摩棒,電動按摩棒,電マ,バイブ,"/>
+    <a zh_cn="男同性恋" zh_tw="男同性戀" jp="ボーイ ズラブ" keyword=",ゲイ,BL（ボーイズラブ）,ボーイズラブ,男同,男同性戀,男同性恋,"/>
+    <a zh_cn="酒店" zh_tw="酒店" jp="ホテル" keyword=",ホテル,酒店,飯店,"/>
+    <a zh_cn="女公关" zh_tw="酒店小姐" jp="キャバ嬢" keyword=",キャバ嬢,風俗嬢,キャバ嬢・風俗嬢,酒店小姐,"/>
+    <a zh_cn="妈妈的朋友" zh_tw="媽媽的朋友" jp="ママ友" keyword=",ママ友,妈妈的朋友,媽媽的朋友,"/>
+    <a zh_cn="喜剧" zh_tw="喜劇" jp="ギャグ・コメディ" keyword=",ギャグ・コメディ,喜剧,爱情喜剧,喜劇,滑稽模仿,堵嘴·喜劇,整人・喜剧,"/>
+    <a zh_cn="恶搞" zh_tw="惡搞" jp="パロディ" keyword=",パロディ,惡搞,整人,"/>
+    <a zh_cn="白眼失神" zh_tw="白眼失神" jp="白目・失神" keyword=",翻白眼・失神,白目・失神,白眼失神,"/>
+    <a zh_cn="白人" zh_tw="白人" jp="白人" keyword=",白人,白人女優,"/>
+    <a zh_cn="招待小姐" zh_tw="招待小姐" jp="受付嬢" keyword=",招待小姐,受付嬢,接待员,"/>
+    <a zh_cn="薄马赛克" zh_tw="薄馬賽克" jp="ギリモザ" keyword=",薄馬賽克,薄马赛克,ギリモザ,"/>
+    <a zh_cn="鼻钩" zh_tw="鼻鉤" jp="鼻フック" keyword=",鼻勾,鼻フック,鼻钩,鼻鉤,"/>
+    <a zh_cn="变性者" zh_tw="變性者" jp="變性者" keyword=",變性者,变性者,变性人,變性人,ニューハーフ,"/>
+    <a zh_cn="医院诊所" zh_tw="醫院診所" jp="病院・クリニック" keyword=",医院・诊所,病院・クリニック,医院诊所,醫院診所,"/>
+    <a zh_cn="社团经理" zh_tw="社團經理" jp="部活・マネージャー" keyword=",社团・经理,部活・マネージャー,社团经理,社團經理,"/>
+    <a zh_cn="下属·同事" zh_tw="下屬·同事" jp="部下・同僚"
+       keyword=",下属・同事,部下・同僚,下属·同事,下屬·同事,同事,下屬,下属,"/>
+    <a zh_cn="残忍画面" zh_tw="殘忍畫面" jp="残虐表現" keyword=",殘忍,殘忍畫面,残忍画面,残虐表現,"/>
+    <a zh_cn="插入异物" zh_tw="插入異物" jp="異物挿入" keyword=",異物挿入,插入異物,插入异物,"/>
+    <a zh_cn="超乳" zh_tw="超乳" jp="超乳" keyword=",超乳,"/>
+    <a zh_cn="潮吹" zh_tw="潮吹" jp="潮吹" keyword=",潮吹,潮吹き,"/>
+    <a zh_cn="男优潮吹" zh_tw="男優潮吹" jp="男の潮吹き" keyword=",男潮吹,男の潮吹き,男优潮吹,男優潮吹,"/>
+    <a zh_cn="巴士导游" zh_tw="巴士導遊" jp="車掌小姐"
+       keyword=",車掌小姐,车掌小姐,巴士乘务员,巴士乘務員,巴士导游,巴士導遊,バスガイド,"/>
+    <a zh_cn="熟女" zh_tw="熟女" jp="熟女" keyword=",熟女,成熟的女人,"/>
+    <a zh_cn="出轨" zh_tw="出軌" jp="出軌" keyword=",出軌,出轨,"/>
+    <a zh_cn="白天出轨" zh_tw="白天出軌" jp="白天出轨" keyword=",白天出軌,白天出轨,通姦,"/>
+    <a zh_cn="处男" zh_tw="處男" jp="童貞" keyword=",處男,处男,童貞,"/>
+    <a zh_cn="处女" zh_tw="處女" jp="處女" keyword=",處女,处女,処女,"/>
+    <a zh_cn="处女作" zh_tw="處女作" jp="デビュー作品" keyword=",處女作,处女作,処女,デビュー作品"/>
+    <a zh_cn="触手" zh_tw="觸手" jp="觸手" keyword=",觸手,触手,"/>
+    <a zh_cn="魔鬼系" zh_tw="魔鬼系" jp="鬼畜" keyword=",魔鬼系,粗暴,胁迫,鬼畜,"/>
+    <a zh_cn="催眠" zh_tw="催眠" jp="催眠" keyword=",催眠,"/>
+    <a zh_cn="打手枪" zh_tw="打手槍" jp="打手槍" keyword=",手淫,打手枪,打手槍,手コキ,"/>
+    <a zh_cn="单体作品" zh_tw="單體作品" jp="單體作品" keyword=",单体作品,單體作品,単体作品,AV女优片,"/>
+    <a zh_cn="荡妇" zh_tw="蕩婦" jp="蕩婦" keyword=",蕩婦,荡妇,"/>
+    <a zh_cn="女方搭讪" zh_tw="女方搭訕" jp="逆ナン" keyword=",倒追,女方搭讪,女方搭訕,搭讪,搭訕,ナンパ,逆ナン,"/>
+    <a zh_cn="女医师" zh_tw="女醫師" jp="女醫師" keyword=",女医师,女醫師,女医,"/>
+    <a zh_cn="主观视角" zh_tw="主觀視角" jp="主觀視角"
+       keyword=",第一人稱攝影,第一人称摄影,主观视角,主觀視角,第一人称视点,主観,"/>
+    <a zh_cn="多P" zh_tw="多P" jp="多P" keyword=",多P,"/>
+    <a zh_cn="恶作剧" zh_tw="惡作劇" jp="イタズラ" keyword=",惡作劇,恶作剧,イタズラ,"/>
+    <a zh_cn="放尿" zh_tw="放尿" jp="放尿" keyword=",放尿,お漏らし,放尿・お漏らし,"/>
+    <a zh_cn="放置" zh_tw="放置" jp="放置" keyword=",放置,"/>
+    <a zh_cn="女服务生" zh_tw="女服務生" jp="ウェイトレス" keyword=",服務生,服务生,女服务生,女服務生,ウェイトレス,"/>
+    <a zh_cn="蒙面" zh_tw="蒙面" jp="覆面・マスク" keyword=",蒙面・面罩,蒙面・面具,覆面・マスク,"/>
+    <a zh_cn="肛门" zh_tw="肛門" jp="アナル" keyword=",肛交,肛門,アナル,"/>
+    <a zh_cn="肛交" zh_tw="肛交" jp="肛交" keyword=",肛交,アナルセックス,"/>
+    <a zh_cn="肛内中出" zh_tw="肛內中出" jp="肛內中出" keyword=",肛内中出,肛內中出,"/>
+    <a zh_cn="个子高" zh_tw="個子高" jp="个子高" keyword=",高,个子高,個子高,"/>
+    <a zh_cn="高中生" zh_tw="高中生" jp="高中生" keyword=",高中女生,高中生,"/>
+    <a zh_cn="歌德萝莉" zh_tw="歌德蘿莉" jp="哥德蘿莉" keyword=",歌德萝莉,哥德蘿莉,歌德蘿莉,"/>
+    <a zh_cn="各种职业" zh_tw="各種職業" jp="各種職業" keyword=",各種職業,各种职业,多種職業,多种职业,職業色々,"/>
+    <a zh_cn="职业装" zh_tw="職業裝" jp="職業裝" keyword=",OL,洽公服装,职业装,職業裝,ビジネススーツ,"/>
+    <a zh_cn="女性向" zh_tw="女性向" jp="女性向け" keyword=",給女性觀眾,给女性观众,女性向,女性向け,"/>
+    <a zh_cn="公主" zh_tw="公主" jp="公主" keyword=",公主,"/>
+    <a zh_cn="故事集" zh_tw="故事集" jp="故事集" keyword=",故事集,"/>
+    <a zh_cn="寡妇" zh_tw="寡婦" jp="未亡人" keyword=",寡婦,寡妇,未亡人,"/>
+    <a zh_cn="灌肠" zh_tw="灌腸" jp="灌腸" keyword=",灌腸,灌肠,浣腸,"/>
+    <a zh_cn="进口" zh_tw="進口" jp="國外進口" keyword=",海外,進口,进口,國外進口,国外进口,海外輸入,洋ピン,洋ピン・海外輸入,"/>
+    <a zh_cn="流汗" zh_tw="流汗" jp="汗だく" keyword=",流汗,汗だく,"/>
+    <a zh_cn="共演" zh_tw="共演" jp="合作作品" keyword=",合作作品,共演,コラボ作品,"/>
+    <a zh_cn="和服・丧服" zh_tw="和服・喪服" jp="和服・喪服"
+       keyword=",和服・丧服,和服，喪服,和服、丧服,和服・喪服,和服·丧服,和服·喪服,"/>
+    <a zh_cn="和服・浴衣" zh_tw="和服・浴衣" jp="和服・浴衣" keyword=",浴衣,和服・浴衣,和服、浴衣,"/>
+    <a zh_cn="调教・奴隶" zh_tw="調教・奴隸" jp="調教・奴隸"
+       keyword=",拷问,拷問,奴隸,奴隶,奴隷,調教・奴隷,調教,调教,调教・奴隶,调教·奴隶,調教·奴隸,調教・奴隸."/>
+    <a zh_cn="黑帮成员" zh_tw="黑幫成員" jp="黑幫成員" keyword=",黑幫成員,黑帮成员,"/>
+    <a zh_cn="黑人" zh_tw="黑人" jp="黑人演員" keyword=",黑人,黑人演員,黑人演员,黒人男優,"/>
+    <a zh_cn="护士" zh_tw="護士" jp="ナース" keyword=",護士,护士,ナース,看護婦,看護婦・ナース,"/>
+    <a zh_cn="痴汉" zh_tw="痴漢" jp="痴漢" keyword=",痴漢,痴汉,"/>
+    <a zh_cn="痴女" zh_tw="癡女" jp="癡女" keyword=",花癡,痴女,癡女,"/>
+    <a zh_cn="新娘" zh_tw="新娘" jp="花嫁" keyword=",花嫁,新娘,"/>
+    <a zh_cn="少妇" zh_tw="少婦" jp="少婦" keyword=",少妇,少婦,若妻・幼妻,年轻妻子,若妻,幼妻"/>
+    <a zh_cn="妄想" zh_tw="妄想" jp="妄想" keyword=",幻想,妄想,妄想族,ファンタジー,"/>
+    <a zh_cn="肌肉" zh_tw="肌肉" jp="肌肉" keyword=",肌肉,"/>
+    <a zh_cn="及膝袜" zh_tw="及膝襪" jp="及膝襪" keyword=",及膝襪,及膝袜,"/>
+    <a zh_cn="纪录片" zh_tw="紀錄片" jp="纪录片" keyword=",紀錄片,纪录片,"/>
+    <a zh_cn="家庭教师" zh_tw="家庭教師" jp="家庭教師" keyword=",家教,家庭教师,家庭教師,"/>
+    <a zh_cn="娇小" zh_tw="嬌小" jp="嬌小的"
+       keyword=",迷你系,迷你係列,娇小,嬌小,瘦小身型,嬌小的,迷你系‧小隻女,ミニ系,ミニ系・小柄,"/>
+    <a zh_cn="性教学" zh_tw="性教學" jp="性教學" keyword=",教學,教学,性教学,性教學,"/>
+    <a zh_cn="姐姐" zh_tw="姐姐" jp="姐姐" keyword=",姐姐,姐姐系,お姉さん,"/>
+    <a zh_cn="姐·妹" zh_tw="姐·妹" jp="姐·妹" keyword=",妹妹,姐妹,姐·妹,姊妹,姉・妹,"/>
+    <a zh_cn="着衣性爱" zh_tw="穿衣幹砲" jp="着エロ" keyword=",着衣,穿衣幹砲,着エロ,"/>
+    <a zh_cn="紧缚" zh_tw="緊縛" jp="緊縛" keyword=",緊縛,紧缚,縛り・緊縛,紧缚,"/>
+    <a zh_cn="紧身衣" zh_tw="緊身衣" jp="緊身衣"
+       keyword=",緊身衣,紧身衣,紧缚皮衣,緊縛皮衣,紧身衣激凸,緊身衣激凸,ボディコン,"/>
+    <a zh_cn="经典老片" zh_tw="經典老片" jp="經典" keyword=",經典,经典,经典老片,經典老片,クラシック,"/>
+    <a zh_cn="拘束" zh_tw="拘束" jp="拘束" keyword=",拘束,"/>
+    <a zh_cn="监禁" zh_tw="監禁" jp="監禁" keyword=",監禁,监禁,"/>
+    <a zh_cn="强奸" zh_tw="強姦" jp="強姦" keyword=",強姦,强奸,強暴,强暴,レイプ,"/>
+    <a zh_cn="轮奸" zh_tw="輪姦" jp="輪姦" keyword=",輪姦,轮奸,轮姦,"/>
+    <a zh_cn="私处近拍" zh_tw="私處近拍" jp="私處近拍" keyword=",私处近拍,私處近拍,局部特寫,局部特写,局部アップ,"/>
+    <a zh_cn="巨尻" zh_tw="巨尻" jp="巨尻" keyword=",大屁股,巨大屁股,巨尻,"/>
+    <a zh_cn="美尻" zh_tw="美尻" jp="美尻" keyword=",美尻,"/>
+    <a zh_cn="巨乳" zh_tw="巨乳" jp="巨乳" keyword=",巨乳,巨乳爆乳,爱巨乳,愛巨乳,巨乳フェチ,"/>
+    <a zh_cn="窈窕" zh_tw="窈窕" jp="スレンダー" keyword=",窈窕,苗条的,苗条,苗條的,スレンダー,"/>
+    <a zh_cn="肌肉" zh_tw="筋肉" jp="筋肉" keyword=",肌肉,肌肉女,筋肉,"/>
+    <a zh_cn="美腿" zh_tw="美腿" jp="美腿" keyword=",美腿,美脚,爱美腿,愛美腿,脚フェチ,"/>
+    <a zh_cn="修长" zh_tw="修長" jp="長身" keyword=",修長,長身,"/>
+    <a zh_cn="美臀" zh_tw="美臀" jp="尻フェチ" keyword=",美臀,屁股,美尻,爱美臀,愛美臀,尻フェチ,"/>
+    <a zh_cn="奇幻" zh_tw="奇幻" jp="科幻" keyword=",科幻,奇幻,SF,"/>
+    <a zh_cn="空姐" zh_tw="空姐" jp="スチュワーデス" keyword=",空中小姐,空姐,スチュワーデス,"/>
+    <a zh_cn="恐怖" zh_tw="恐怖" jp="ホラー" keyword=",恐怖,ホラー,"/>
+    <a zh_cn="口交" zh_tw="口交" jp="フェラ" keyword=",口交,フェラ,双重口交,雙重口交,Wフェラ,"/>
+    <a zh_cn="深喉" zh_tw="深喉" jp="イラマチオ" keyword=",深喉,喉奥,强迫口交,強迫口交,イラマチオ,"/>
+    <a zh_cn="偷拍" zh_tw="偷拍" jp="盗撮" keyword=",偷拍,盗撮,盗撮・のぞき,"/>
+    <a zh_cn="蜡烛" zh_tw="蠟燭" jp="蝋燭" keyword=",蜡烛,蝋燭,蠟燭,"/>
+    <a zh_cn="滥交" zh_tw="濫交" jp="濫交" keyword=",濫交,滥交,乱交,亂交,"/>
+    <a zh_cn="酒醉" zh_tw="酒醉" jp="爛醉如泥的" keyword=",爛醉如泥的,烂醉如泥的,酒醉,"/>
+    <a zh_cn="立即插入" zh_tw="立即插入" jp="立即插入" keyword=",立即口交,即兴性交,立即插入,马上幹,馬上幹,即ハメ,"/>
+    <a zh_cn="连裤袜" zh_tw="連褲襪" jp="連褲襪" keyword=",連褲襪,连裤袜,"/>
+    <a zh_cn="连发" zh_tw="連發" jp="連発" keyword=",连发,連發,連発,"/>
+    <a zh_cn="恋爱" zh_tw="戀愛" jp="恋愛" keyword=",戀愛,恋爱,恋愛,"/>
+    <a zh_cn="恋乳癖" zh_tw="戀乳癖" jp="戀乳癖" keyword=",戀乳癖,恋乳癖,"/>
+    <a zh_cn="恋腿癖" zh_tw="戀腿癖" jp="戀腿癖" keyword=",戀腿癖,恋腿癖,"/>
+    <a zh_cn="猎艳" zh_tw="獵艷" jp="獵豔" keyword=",獵豔,猎艳,獵艷,"/>
+    <a zh_cn="乱伦" zh_tw="亂倫" jp="亂倫" keyword=",亂倫,乱伦,"/>
+    <a zh_cn="萝莉" zh_tw="蘿莉" jp="蘿莉塔" keyword=",蘿莉塔,萝莉塔,ロリ,"/>
+    <a zh_cn="裸体围裙" zh_tw="裸體圍裙" jp="裸體圍裙" keyword=",裸體圍裙,裸体围裙,真空围裙,真空圍裙,裸エプロン,"/>
+    <a zh_cn="旅行" zh_tw="旅行" jp="旅行" keyword=",旅行,"/>
+    <a zh_cn="骂倒" zh_tw="罵倒" jp="罵倒" keyword=",罵倒,骂倒,"/>
+    <a zh_cn="傲娇" zh_tw="傲娇" jp="ツンデレ" keyword=",蠻橫嬌羞,蛮横娇羞,ツンデレ,"/>
+    <a zh_cn="猫耳" zh_tw="貓耳" jp="ネコミミ" keyword=",貓耳女,猫耳女,ネコミミ・獣系,"/>
+    <a zh_cn="美容院" zh_tw="美容院" jp="美容院" keyword=",美容院,エステ,"/>
+    <a zh_cn="短裙" zh_tw="短裙" jp="短裙" keyword=",短裙,"/>
+    <a zh_cn="美少女" zh_tw="美少女" jp="美少女" keyword=",美少女,美少女電影,美少女电影,"/>
+    <a zh_cn="迷你裙" zh_tw="迷你裙" jp="迷你裙" keyword=",迷你裙,ミニスカ,"/>
+    <a zh_cn="迷你裙警察" zh_tw="迷你裙警察" jp="ミニスカポリス" keyword=",迷你裙警察,ミニスカポリス,"/>
+    <a zh_cn="秘书" zh_tw="秘書" jp="秘書" keyword=",秘書,秘书,"/>
+    <a zh_cn="面试" zh_tw="面試" jp="面接" keyword=",面试,面接,面試,"/>
+    <a zh_cn="明星脸" zh_tw="明星臉" jp="そっくりさん" keyword=",明星臉,明星脸,そっくりさん,"/>
+    <a zh_cn="模特" zh_tw="模特" jp="模特兒" keyword=",模特兒,模特儿,モデル,"/>
+    <a zh_cn="魔法少女" zh_tw="魔法少女" jp="魔法少女" keyword=",魔法少女,"/>
+    <a zh_cn="母亲" zh_tw="母親" jp="母親" keyword=",母親,母亲,妈妈系,媽媽系,お母さん,"/>
+    <a zh_cn="义母" zh_tw="義母" jp="母親" keyword=",义母,義母,"/>
+    <a zh_cn="母乳" zh_tw="母乳" jp="母乳" keyword=",母乳,"/>
+    <a zh_cn="女强男" zh_tw="女强男" jp="逆レイプ" keyword=",逆レイプ,女强男,"/>
+    <a zh_cn="养女" zh_tw="養女" jp="娘・養女" keyword=",养女,娘・養女,"/>
+    <a zh_cn="年轻女孩" zh_tw="年輕女孩" jp="お嬢様・令嬢" keyword=",お嬢様・令嬢,お嬢様,令嬢,年輕女孩,年轻女孩,"/>
+    <a zh_cn="女大学生" zh_tw="女大學生" jp="女子大生" keyword=",女大學生,女大学生,女子大生,"/>
+    <a zh_cn="女祭司" zh_tw="女祭司" jp="女祭司" keyword=",女祭司,"/>
+    <a zh_cn="女搜查官" zh_tw="女搜查官" jp="女檢察官" keyword=",女檢察官,女检察官,女搜查官,"/>
+    <a zh_cn="女教师" zh_tw="女教師" jp="女教師" keyword=",女教師,女教师,"/>
+    <a zh_cn="女忍者" zh_tw="女忍者" jp="女忍者" keyword=",女忍者,くノ一,"/>
+    <a zh_cn="女上司" zh_tw="女上司" jp="女上司" keyword=",女上司,"/>
+    <a zh_cn="女战士" zh_tw="女戦士" jp="女戦士" keyword=",女戦士,"/>
+    <a zh_cn="女搜查官" zh_tw="女捜査官" jp="女捜査官" keyword=",女捜査官,"/>
+    <a zh_cn="骑乘位" zh_tw="騎乘位" jp="騎乗位" keyword=",女上位,骑乘,騎乘,骑乘位,騎乘位,騎乗位,"/>
+    <a zh_cn="辣妹" zh_tw="辣妹" jp="辣妹" keyword=",女生,辣妹,ギャル,"/>
+    <a zh_cn="女同性恋" zh_tw="女同性戀" jp="女同性戀" keyword=",女同性戀,女同性恋,女同志,レズ,レズキス,レズビアン,"/>
+    <a zh_cn="女王" zh_tw="女王" jp="女王様" keyword=",女王,女王様,"/>
+    <a zh_cn="女医生" zh_tw="女醫生" jp="女醫生" keyword=",女醫生,女医生,"/>
+    <a zh_cn="女仆" zh_tw="女僕" jp="メイド" keyword=",女傭,女佣,女仆,女僕,メイド,"/>
+    <a zh_cn="女优最佳合集" zh_tw="女優最佳合集" jp="女優ベスト・総集編"
+       keyword=",女優ベスト・総集編,女优最佳合集,女優最佳合集,ベスト・総集編,"/>
+    <a zh_cn="超級女英雄" zh_tw="超級女英雄" jp="変身ヒロイン" keyword=",行動,行动,超級女英雄,変身ヒロイン,"/>
+    <a zh_cn="女主播" zh_tw="女主播" jp="女子アナ" keyword=",女主播,女子アナ,"/>
+    <a zh_cn="女主人" zh_tw="女主人" jp="老闆娘"
+       keyword=",女主人,老闆娘，女主人,老板娘、女主人,女主人、女老板,女将・女主人,"/>
+    <a zh_cn="女装人妖" zh_tw="女裝人妖" jp="女裝人妖" keyword=",女裝人妖,女装人妖,女装・男の娘,"/>
+    <a zh_cn="扶她" zh_tw="扶她" jp="ふたなり" keyword=",扶她,ふたなり,"/>
+    <a zh_cn="呕吐" zh_tw="嘔吐" jp="嘔吐" keyword=",呕吐,嘔吐,ゲロ,"/>
+    <a zh_cn="粪便" zh_tw="糞便" jp="糞便" keyword=",脱糞,排便,粪便,糞便,食糞,食粪,スカトロ,"/>
+    <a zh_cn="丰满" zh_tw="豐滿" jp="ぽっちゃり" keyword=",丰满,豐滿,胖女人,坦克,"/>
+    <a zh_cn="泡泡袜" zh_tw="泡泡襪" jp="泡泡襪" keyword=",泡泡袜,泡泡襪,ルーズソックス,"/>
+    <a zh_cn="泡沫浴" zh_tw="泡沫浴" jp="泡沫浴" keyword=",泡沫浴,"/>
+    <a zh_cn="平胸" zh_tw="平胸" jp="貧乳・微乳" keyword=",平胸,貧乳・微乳,"/>
+    <a zh_cn="丈母娘" zh_tw="丈母娘" jp="婆婆" keyword=",婆婆,后母,丈母娘,"/>
+    <a zh_cn="恋物癖" zh_tw="戀物癖" jp="戀物癖" keyword="戀物癖,恋物癖,其他戀物癖,其他恋物癖,"/>
+    <a zh_cn="其他癖好" zh_tw="其他癖好" jp="その他フェチ" keyword="其他癖好,その他フェチ,"/>
+    <a zh_cn="旗袍" zh_tw="旗袍" jp="チャイナドレス" keyword=",旗袍,チャイナドレス,"/>
+    <a zh_cn="企画" zh_tw="企畫" jp="企畫" keyword=",企畫,企画,"/>
+    <a zh_cn="车震" zh_tw="車震" jp="汽車性愛" keyword=",汽車性愛,汽车性爱,车震,車震,车床族,車床族,カーセックス,"/>
+    <a zh_cn="大小姐" zh_tw="大小姐" jp="お姫様" keyword=",大小姐,千金小姐,お姫様,"/>
+    <a zh_cn="情侣" zh_tw="情侶" jp="情侶" keyword=",情侶,情侣,伴侶,伴侣,コンパニオン,カップル,"/>
+    <a zh_cn="拳交" zh_tw="拳交" jp="フィスト" keyword=",拳交,フィスト,"/>
+    <a zh_cn="晒痕" zh_tw="曬痕" jp="日焼け" keyword=",曬黑,晒黑,日焼け,"/>
+    <a zh_cn="美乳" zh_tw="美乳" jp="美乳" keyword=",乳房,美乳,"/>
+    <a zh_cn="乳交" zh_tw="乳交" jp="乳交" keyword=",乳交,パイズリ,"/>
+    <a zh_cn="乳液" zh_tw="乳液" jp="乳液" keyword=",乳液,ローション・オイル,ローション·オイル,"/>
+    <a zh_cn="软体" zh_tw="軟體" jp="軟体" keyword=",软体,軟体,軟體,"/>
+    <a zh_cn="挠痒痒" zh_tw="搔癢" jp="くすぐり" keyword=",くすぐり,挠痒痒,搔痒,瘙癢,搔癢,"/>
+    <a zh_cn="设计环节" zh_tw="設計環節" jp="設置項目" keyword=",設置項目,设计环节,設計環節,"/>
+    <a zh_cn="丰乳肥臀" zh_tw="豐乳肥臀" jp="身體意識" keyword=",身體意識,身体意识,丰乳肥臀,豐乳肥臀,"/>
+    <a zh_cn="时间停止" zh_tw="時間停止" jp="時間停止" keyword=",时间停止,時間停止,"/>
+    <a zh_cn="手指插入" zh_tw="插入手指" jp="手マン" keyword=",手指插入,插入手指,手マン,"/>
+    <a zh_cn="首次亮相" zh_tw="首次亮相" jp="首次亮相" keyword=",首次亮相,"/>
+    <a zh_cn="叔母" zh_tw="叔母" jp="叔母さん" keyword=",叔母,叔母さん,"/>
+    <a zh_cn="双性人" zh_tw="雙性人" jp="雙性人" keyword=",雙性人,双性人,"/>
+    <a zh_cn="韵律服" zh_tw="韻律服" jp="レオタード" keyword=",韵律服,韻律服,レオタード,"/>
+    <a zh_cn="水手服" zh_tw="水手服" jp="セーラー服" keyword=",水手服,セーラー服,"/>
+    <a zh_cn="丝袜" zh_tw="絲襪" jp="パンスト・タイツ" keyword=",丝袜,絲襪,パンスト,パンスト・タイツ,"/>
+    <a zh_cn="特摄" zh_tw="特攝" jp="特撮" keyword=",特效,特摄,特攝,特撮,"/>
+    <a zh_cn="经历告白" zh_tw="經歷告白" jp="体験告白" keyword=",體驗懺悔,经历告白,經歷告白,体験告白,"/>
+    <a zh_cn="体操服" zh_tw="體操服" jp="体操着" keyword=",体操服,體育服,體操服,体操着・ブルマ,"/>
+    <a zh_cn="舔阴" zh_tw="舔陰" jp="舔陰" keyword=",舔陰,舔阴,舔鲍,クンニ,"/>
+    <a zh_cn="阴道观察" zh_tw="阴道观察" jp="阴道观察" keyword=",阴道观察,クスコ,扩阴器,"/>
+    <a zh_cn="跳蛋" zh_tw="跳蛋" jp="ローター" keyword=",跳蛋,ローター,"/>
+    <a zh_cn="跳舞" zh_tw="跳舞" jp="跳舞" keyword=",跳舞,ダンス,"/>
+    <a zh_cn="台湾模特" zh_tw="臺灣模特" jp="台湾モデル" keyword=",台湾模特,台湾モデル,"/>
+    <a zh_cn="青梅竹马" zh_tw="青梅竹馬" jp="幼なじみ" keyword=",幼驯染,童年朋友,青梅竹马,青梅竹馬,幼なじみ,"/>
+    <a zh_cn="偷窥" zh_tw="偷窺" jp="偷窥" keyword=",偷窺,偷窥,"/>
+    <a zh_cn="投稿" zh_tw="投稿" jp="投稿" keyword=",投稿,"/>
+    <a zh_cn="赛车女郎" zh_tw="賽車女郎" jp="レースクィーン" keyword=",賽車女郎,赛车女郎,レースクィーン,"/>
+    <a zh_cn="兔女郎" zh_tw="兔女郎" jp="兔女郎" keyword=",兔女郎,バニーガール,"/>
+    <a zh_cn="吞精" zh_tw="吞精" jp="吞精" keyword=",吞精,ごっくん,"/>
+    <a zh_cn="成人动画" zh_tw="成人動畫" jp="アニメ" keyword=",成人动画,成人動畫,成人アニメ,"/>
+    <a zh_cn="成人玩偶" zh_tw="成人玩偶" jp="ドール" keyword=",玩偶,娃娃,成人娃娃,ドール"/>
+    <a zh_cn="玩具" zh_tw="玩具" jp="おもちゃ" keyword=",玩具,玩物,おもちゃ,"/>
+    <a zh_cn="适合手机垂直播放" zh_tw="適合手機垂直播放" jp="スマホ推奨縦動画"
+       keyword=",スマホ推奨縦動画,スマホ専用縦動画,為智能手機推薦垂直視頻,适合手机垂直播放,適合手機垂直播放,"/>
+    <a zh_cn="猥亵穿着" zh_tw="猥褻穿着" jp="猥褻穿著" keyword=",猥褻穿著,猥亵穿着,猥褻穿着,"/>
+    <a zh_cn="无码流出" zh_tw="無碼流出" jp="无码流出" keyword=",無碼流出,无码流出,"/>
+    <a zh_cn="无码破解" zh_tw="無碼破解" jp="無碼破解" keyword=",無碼破解,无码破解,"/>
+    <a zh_cn="无毛" zh_tw="無毛" jp="無毛" keyword=",無毛,无毛,剃毛,白虎,パイパン,"/>
+    <a zh_cn="剧情" zh_tw="劇情" jp="戲劇" keyword=",戲劇,戏剧,剧情,劇情,戲劇x,戏剧、连续剧,戲劇、連續劇,ドラマ,"/>
+    <a zh_cn="性转换·男变女" zh_tw="性轉換·男變女" jp="性別轉型·女性化"
+       keyword=",性转换・女体化,性別轉型·女性化,性转换·男变女,性轉換·男變女,性転換・女体化,"/>
+    <a zh_cn="性奴" zh_tw="性奴" jp="性奴" keyword=",性奴,"/>
+    <a zh_cn="性骚扰" zh_tw="性騷擾" jp="性騷擾" keyword=",性騷擾,性骚扰,"/>
+    <a zh_cn="故意露胸" zh_tw="故意露胸" jp="胸チラ" keyword=",胸チラ,故意露胸,"/>
+    <a zh_cn="羞耻" zh_tw="羞恥" jp="羞恥" keyword=",羞恥,羞耻,"/>
+    <a zh_cn="学生" zh_tw="學生" jp="學生" keyword=",學生,其他學生,其他学生,學生（其他）,学生,"/>
+    <a zh_cn="学生妹" zh_tw="學生妹" jp="學生妹" keyword=",学生妹,學生妹,女子校生,"/>
+    <a zh_cn="学生服" zh_tw="學生服" jp="學生服" keyword=",学生服,學生服,"/>
+    <a zh_cn="学生泳装" zh_tw="學生泳裝" jp="學校泳裝"
+       keyword=",學校泳裝,学校泳装,学生泳装,學生泳裝,校园泳装,校園泳裝,競泳・スクール水着,"/>
+    <a zh_cn="泳装" zh_tw="泳裝" jp="水着" keyword=",泳裝,泳装,水着,"/>
+    <a zh_cn="巫女服" zh_tw="巫女服" jp="巫女" keyword=",巫女服,巫女,"/>
+    <a zh_cn="校园" zh_tw="校園" jp="學校作品" keyword=",學校作品,学校作品,校园,校園,校园物语,校園物語,学園もの,"/>
+    <a zh_cn="肛检" zh_tw="肛檢" jp="鴨嘴" keyword=",鴨嘴,鸭嘴,肛检,肛檢,"/>
+    <a zh_cn="骑脸" zh_tw="騎臉" jp="顏面騎乘" keyword=",騎乗位,颜面骑乘,顏面騎乘,骑脸,騎臉,"/>
+    <a zh_cn="颜射" zh_tw="顏射" jp="ぶっかけ" keyword=",顏射,颜射,顏射x,顔射,ぶっかけ,"/>
+    <a zh_cn="眼镜" zh_tw="眼鏡" jp="眼鏡" keyword=",眼鏡,眼镜,メガネ,めがね"/>
+    <a zh_cn="药物" zh_tw="藥物" jp="藥物" keyword=",藥物,药物,药物、迷姦,藥物、迷姦,ドラッグ,"/>
+    <a zh_cn="野外露出" zh_tw="野外露出" jp="野外・露出" keyword=",野外・露出,野外露出,野外,"/>
+    <a zh_cn="业余" zh_tw="業餘" jp="素人" keyword=",業餘,业余,素人,"/>
+    <a zh_cn="人妻" zh_tw="人妻" jp="已婚婦女" keyword=",已婚婦女,已婚妇女,人妻主婦,人妻,主婦,人妻・主婦,"/>
+    <a zh_cn="近亲相奸" zh_tw="近親相姦" jp="近親相姦" keyword=",近亲相姦,近親相姦,"/>
+    <a zh_cn="自拍" zh_tw="自拍" jp="ハメ撮り" keyword=",自拍,ハメ撮り,個人撮影,个人撮影,"/>
+    <a zh_cn="淫语" zh_tw="淫語" jp="淫語" keyword=",淫語,淫语,"/>
+    <a zh_cn="酒会" zh_tw="酒會" jp="飲み会・合コン" keyword=",饮酒派对,飲み会・合コン,酒会,酒會,"/>
+    <a zh_cn="饮尿" zh_tw="飲尿" jp="飲尿" keyword=",飲尿,饮尿,"/>
+    <a zh_cn="游戏改" zh_tw="遊戲改" jp="遊戲的真人版" keyword=",遊戲的真人版,游戏改,遊戲改,ゲーム実写版,"/>
+    <a zh_cn="漫改" zh_tw="漫改" jp="原作コラボ" keyword=",原作改編,原作改编,原作コラボ,漫改,"/>
+    <a zh_cn="受孕" zh_tw="受孕" jp="孕ませ" keyword=",受孕,孕ませ,"/>
+    <a zh_cn="孕妇" zh_tw="孕婦" jp="孕婦" keyword=",孕婦,孕妇,妊婦,"/>
+    <a zh_cn="早泄" zh_tw="早泄" jp="早漏" keyword=",早洩,早漏,早泄,"/>
+    <a zh_cn="Show Girl" zh_tw="Show Girl" jp="展場女孩" keyword=",展場女孩,展场女孩,Show Girl,"/>
+    <a zh_cn="指南" zh_tw="指北" jp="しなん" keyword="指南,教程,How To,"/>
+    <a zh_cn="制服" zh_tw="制服" jp="制服" keyword=",制服,"/>
+    <a zh_cn="中出" zh_tw="中出" jp="中出" keyword=",内射,体内射精,中出,中出し,"/>
+    <a zh_cn="子宫颈" zh_tw="子宮頸" jp="ポルチオ" keyword=",子宮頸,子宫颈,ポルチオ,"/>
+    <a zh_cn="足交" zh_tw="足交" jp="足交" keyword=",足交,足コキ,"/>
+    <a zh_cn="4小时+" zh_tw="4小時+" jp="4小時以上作品" keyword=",4時間以上作品,4小時以上作品,4小时以上作品,4小时+,4小時+,"/>
+    <a zh_cn="69" zh_tw="69" jp="69" keyword=",69,69式,シックスナイン,"/>
+    <a zh_cn="学生" zh_tw="學生" jp="學生" keyword=",C学生,學生,"/>
+    <a zh_cn="M男" zh_tw="M男" jp="M男" keyword=",M男,"/>
+    <a zh_cn="暗黑系" zh_tw="暗黑系" jp="暗黑系" keyword=",暗黑系,黑暗系統,ダーク系,"/>
+    <a zh_cn="成人电影" zh_tw="成人電影" jp="成人電影" keyword=",成人電影,成人电影,"/>
+    <a zh_cn="成人动漫" zh_tw="成人動漫" jp="成人動漫" keyword=",成人动漫,成人動漫,"/>
+    <a zh_cn="导尿" zh_tw="導尿" jp="導尿" keyword=",導尿,导尿,"/>
+    <a zh_cn="法国" zh_tw="法國" jp="法國" keyword=",法国,法國,"/>
+    <a zh_cn="飞特族" zh_tw="飛特族" jp="飛特族" keyword=",飛特族,飞特族,"/>
+    <a zh_cn="韩国" zh_tw="韓國" jp="韓國" keyword=",韓國,韩国,"/>
+    <a zh_cn="户外" zh_tw="戶外" jp="戶外" keyword=",戶外,户外,"/>
+    <a zh_cn="角色对换" zh_tw="角色對換" jp="角色對換" keyword=",角色对换,角色對換,"/>
+    <a zh_cn="精选综合" zh_tw="精選綜合" jp="合集" keyword=",精選，綜合,精选、综合,合集,精选综合,精選綜合,"/>
+    <a zh_cn="捆绑" zh_tw="捆綁" jp="ボンテージ" keyword=",捆綁,捆绑,折磨,ボンテージ,"/>
+    <a zh_cn="礼仪小姐" zh_tw="禮儀小姐" jp="禮儀小姐" keyword=",禮儀小姐,礼仪小姐,"/>
+    <a zh_cn="历史剧" zh_tw="歷史劇" jp="歷史劇" keyword=",歷史劇,历史剧,"/>
+    <a zh_cn="露出" zh_tw="露出" jp="露出" keyword=",露出,"/>
+    <a zh_cn="母狗" zh_tw="母狗" jp="母狗" keyword=",母犬,母狗,"/>
+    <a zh_cn="男优介绍" zh_tw="男優介紹" jp="男優介紹" keyword=",男性,男优介绍,男優介紹,"/>
+    <a zh_cn="女儿" zh_tw="女兒" jp="女兒" keyword=",女兒,女儿,"/>
+    <a zh_cn="全裸" zh_tw="全裸" jp="全裸" keyword=",全裸,"/>
+    <a zh_cn="窥乳" zh_tw="窺乳" jp="窺乳" keyword=",乳房偷窺,窥乳,窺乳,"/>
+    <a zh_cn="羞辱" zh_tw="羞辱" jp="辱め" keyword=",凌辱,羞辱,辱め,辱骂,辱罵,"/>
+    <a zh_cn="脱衣" zh_tw="脫衣" jp="脫衣" keyword=",脫衣,脱衣,"/>
+    <a zh_cn="宣传女郎" zh_tw="宣傳女郎" jp="キャンギャル" keyword=",campaign girl,活动女郎,宣传女郎,活動女郎,宣傳女郎,キャンギャル,"/>
+    <a zh_cn="西洋片" zh_tw="西洋片" jp="西洋片" keyword=",西洋片,"/>
+    <a zh_cn="写真偶像" zh_tw="寫真偶像" jp="寫真偶像" keyword=",寫真偶像,写真偶像,"/>
+    <a zh_cn="修女" zh_tw="修女" jp="修女" keyword=",修女,"/>
+    <a zh_cn="偶像艺人" zh_tw="偶像藝人" jp="アイドル芸能人"
+       keyword=",藝人,艺人,偶像,偶像藝人,偶像艺人,偶像‧藝人,偶像‧艺人,アイドル・芸能人,"/>
+    <a zh_cn="淫乱真实" zh_tw="淫亂真實" jp="淫亂真實" keyword=",淫亂，真實,淫乱、真实,淫乱真实,淫亂真實,淫乱・ハード系,"/>
+    <a zh_cn="瑜伽·健身" zh_tw="瑜伽·健身" jp="瑜伽·健身" keyword=",瑜伽,瑜伽·健身,ヨガ,講師,讲师"/>
+    <a zh_cn="运动短裤" zh_tw="運動短褲" jp="運動短褲" keyword=",運動短褲,运动短裤,"/>
+    <a zh_cn="JK制服" zh_tw="JK制服" jp="JK制服" keyword=",制服外套,JK制服,校服,"/>
+    <a zh_cn="重制版" zh_tw="重製版" jp="複刻版" keyword=",重印版,複刻版,重制版,重製版,"/>
+    <a zh_cn="综合短篇" zh_tw="綜合短篇" jp="綜合短篇" keyword=",綜合短篇,综合短篇,"/>
+    <a zh_cn="被外国人干" zh_tw="被外國人乾" jp="被外國人乾" keyword=",被外國人幹,被外国人干,被外國人乾,"/>
+    <a zh_cn="二穴同入" zh_tw="二穴同入" jp="二穴同入" keyword=",二穴同時挿入,二穴同入,"/>
+    <a zh_cn="美脚" zh_tw="美腳" jp="美腳" keyword=",美腳,美脚,"/>
+    <a zh_cn="过膝袜" zh_tw="過膝襪" jp="ニーソックス" keyword=",絲襪、過膝襪,ニーソックス,"/>
+    <a zh_cn="名人" zh_tw="名人" jp="名人" keyword=",名人,"/>
+    <a zh_cn="黑白配" zh_tw="黑白配" jp="黑白配" keyword=",黑白配,"/>
+    <a zh_cn="AI生成作品" zh_tw="AI生成作品" jp="AI生成作品" keyword=",AI生成作品,"/>
+    <a zh_cn="黑道" zh_tw="黑道" jp="極道" keyword=",黑道,黑帮,黑社会,黑幫,黑社會,极道,極道,極道・任侠,"/>
+    <a zh_cn="欲女" zh_tw="欲女" jp="エマニエル" keyword=",エマニエル,欲女,"/>
+    <a zh_cn="高筒靴" zh_tw="高筒靴" jp="高筒靴" keyword=",靴子,高筒靴,"/>
+    <a zh_cn="双飞" zh_tw="雙飛" jp="雙飛" keyword=",兩女一男,双飞,雙飛,"/>
+    <a zh_cn="两女两男" zh_tw="兩女兩男" jp="兩女兩男" keyword=",兩男兩女,两女两男,兩女兩男,"/>
+    <a zh_cn="两男一女" zh_tw="兩男一女" jp="兩男一女" keyword=",兩男一女,两男一女,"/>
+    <a zh_cn="3P・4P" zh_tw="3P・4P" jp="3P・4P" keyword=",4P,4p,3P,3p,3P・4P,"/>
+    <a zh_cn="唾液敷面" zh_tw="唾液敷面" jp="唾液敷面" keyword=",唾液敷面,"/>
+    <a zh_cn="kira☆kira" zh_tw="kira☆kira" jp="kira☆kira" keyword=",kira☆kira,"/>
+    <a zh_cn="S1 NO.1 STYLE" zh_tw="S1 NO.1 STYLE" jp="S1 NO.1 STYLE"
+       keyword=",S1 Style,エスワン,エスワン ナンバーワンスタイル,エスワンナンバーワンスタイル,S1 NO.1 STYLE,S1NO.1STYLE,"/>
+    <a zh_cn="一本道" zh_tw="一本道" jp="一本道" keyword=",一本道,"/>
+    <a zh_cn="加勒比" zh_tw="加勒比" jp="加勒比" keyword=",加勒比,カリビアンコム,"/>
+    <a zh_cn="东京热" zh_tw="東京熱" jp="TOKYO-HOT" keyword=",东京热,東京熱,東熱,TOKYO-HOT,"/>
+    <a zh_cn="SOD" zh_tw="SOD" jp="SOD" keyword=",SOD,SODクリエイト,"/>
+    <a zh_cn="PRESTIGE" zh_tw="PRESTIGE" jp="PRESTIGE" keyword=",PRESTIGE,プレステージ,"/>
+    <a zh_cn="MOODYZ" zh_tw="MOODYZ" jp="MOODYZ" keyword=",MOODYZ,ムーディーズ,"/>
+    <a zh_cn="ROCKET" zh_tw="ROCKET" jp="ROCKET" keyword=",ROCKET,"/>
+    <a zh_cn="S级素人" zh_tw="S級素人" jp="S級素人" keyword=",S級素人,アイデアポケット,"/>
+    <a zh_cn="HEYZO" zh_tw="HEYZO" jp="HEYZO" keyword=",HEYZO,"/>
+    <a zh_cn="玛丹娜" zh_tw="瑪丹娜" jp="Madonna" keyword=",玛丹娜,瑪丹娜,マドンナ,Madonna,"/>
+    <a zh_cn="MAXING" zh_tw="MAXING" jp="MAXING" keyword=",MAXING,マキシング,"/>
+    <a zh_cn="JAPANKET" zh_tw="ALICE JAPAN" jp="ALICE JAPAN" keyword=",ALICE JAPAN,アリスJAPAN,"/>
+    <a zh_cn="E-BODY" zh_tw="E-BODY" jp="E-BODY" keyword=",E-BODY,"/>
+    <a zh_cn="Natural High" zh_tw="Natural High" jp="Natural High" keyword=",Natural High,ナチュラルハイ,"/>
+    <a zh_cn="美" zh_tw="美" jp="美" keyword=",美,"/>
+    <a zh_cn="K.M.P" zh_tw="K.M.P" jp="K.M.P" keyword=",K.M.P,ケイ・エム・プロデュース,"/>
+    <a zh_cn="Hunter" zh_tw="Hunter" jp="Hunter" keyword=",Hunter,"/>
+    <a zh_cn="OPPAI" zh_tw="OPPAI" jp="OPPAI" keyword=",OPPAI,"/>
+    <a zh_cn="熘池五郎" zh_tw="溜池五郎" jp="溜池ゴロー" keyword=",熘池五郎,溜池五郎,溜池ゴロー,"/>
+    <a zh_cn="kawaii" zh_tw="kawaii" jp="kawaii" keyword=",kawaii,"/>
+    <a zh_cn="PREMIUM" zh_tw="PREMIUM" jp="PREMIUM" keyword=",PREMIUM,プレミアム,"/>
+    <a zh_cn="ヤル男" zh_tw="ヤル男" jp="ヤル男" keyword=",ヤル男,"/>
+    <a zh_cn="ラグジュTV" zh_tw="ラグジュTV" jp="ラグジュTV" keyword=",ラグジュTV,"/>
+    <a zh_cn="シロウトTV" zh_tw="シロウトTV" jp="シロウトTV" keyword=",シロウトTV,"/>
+    <a zh_cn="本中" zh_tw="本中" jp="本中" keyword=",本中,"/>
+    <a zh_cn="WANZ" zh_tw="WANZ" jp="WANZ" keyword=",WANZ,ワンズファクトリー,"/>
+    <a zh_cn="BeFree" zh_tw="BeFree" jp="BeFree" keyword=",BeFree,"/>
+    <a zh_cn="MAX-A" zh_tw="MAX-A" jp="MAX-A" keyword=",MAX-A,マックスエー,"/>
+
 </info>


### PR DESCRIPTION
### 更新
1. 映射了截至2025年12月6日，dmm.jp站内的所有标签
2. 修正此前不准确或缺失映射的翻译,如“クスコ”，“おもちゃ”，“ぶっかけ” 等
3. 更新了tag删除列表，比如 "セット商品" "FANZA配信限定"等

### 效果
使得标签刮取结果更加一致，至少在dmm站刮取时切到简体中文后应该不会出现中日文标签混杂的情况